### PR TITLE
MWPW-145669: move up mediator and change name

### DIFF
--- a/blocks/events-form/events-form.js
+++ b/blocks/events-form/events-form.js
@@ -108,7 +108,7 @@ function createButton({ type, label }, successMsg, rsvpData) {
 
         rsvpData.attendeeId = submissionResp.attendeeId;
         rsvpData.resp = submissionResp;
-        window.bm8tr.set('rsvpData', rsvpData);
+        window.bm8r.set('rsvpData', rsvpData);
 
         clearForm(form);
         const block = button.closest('.events-form');
@@ -301,7 +301,7 @@ function decorateSuccessMsg(form, successMsg, rsvpData) {
       if (i === 0) {
         const resp = await deleteAttendee(rsvpData.eventId, rsvpData.attendeeId);
         rsvpData.resp = resp;
-        window.bm8tr.set('rsvpData', rsvpData);
+        window.bm8r.set('rsvpData', rsvpData);
       }
 
       const modal = form.closest('.dialog-modal');
@@ -322,7 +322,7 @@ async function createForm(formURL, successMsg, formData, terms) {
   }
 
   const rsvpData = { eventId: getMetadata('event-id') || '', attendeeId: '' };
-  window.bm8tr.set('rsvpData', rsvpData);
+  window.bm8r.set('rsvpData', rsvpData);
 
   const { pathname } = new URL(formURL);
   let json = formData;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,7 +15,6 @@ import { captureProfile } from '../utils/event-apis.js';
 import BlockMediator from '../deps/block-mediator.min.js';
 
 /**
- * Moving mediator up since it is not loading in time for autolinks
  * decorateAra function executions'
  */
 window.bm8r = BlockMediator;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -19,7 +19,7 @@ import BlockMediator from '../deps/block-mediator.min.js';
  * to update. Should very litle to non visibile impact on the
  * decorateAra function executions'
  */
-window.bm8tr = BlockMediator;
+window.bm8r = BlockMediator;
 
 // Add project-wide style path here.
 const STYLES = '';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,7 +14,6 @@ import { setLibs, decorateArea } from './utils.js';
 import { captureProfile } from '../utils/event-apis.js';
 import BlockMediator from '../deps/block-mediator.min.js';
 
-/**
  * decorateAra function executions'
  */
 window.bm8r = BlockMediator;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,8 +14,6 @@ import { setLibs, decorateArea } from './utils.js';
 import { captureProfile } from '../utils/event-apis.js';
 import BlockMediator from '../deps/block-mediator.min.js';
 
- * decorateAra function executions'
- */
 window.bm8r = BlockMediator;
 
 // Add project-wide style path here.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,6 +12,14 @@
 
 import { setLibs, decorateArea } from './utils.js';
 import { captureProfile } from '../utils/event-apis.js';
+import BlockMediator from '../deps/block-mediator.min.js';
+
+/**
+ * Moving mediator up since it is not loading in time for autolinks
+ * to update. Should very litle to non visibile impact on the
+ * decorateAra function executions'
+ */
+window.bm8tr = BlockMediator;
 
 // Add project-wide style path here.
 const STYLES = '';
@@ -45,8 +53,6 @@ decorateArea();
  */
 
 const miloLibs = setLibs(LIBS);
-
-window.bm8tr = await import('../deps/block-mediator.min.js').then((mod) => mod.default);
 
 (function loadStyles() {
   const paths = [`${miloLibs}/styles/styles.css`];

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -16,7 +16,6 @@ import BlockMediator from '../deps/block-mediator.min.js';
 
 /**
  * Moving mediator up since it is not loading in time for autolinks
- * to update. Should very litle to non visibile impact on the
  * decorateAra function executions'
  */
 window.bm8r = BlockMediator;

--- a/utils/event-apis.js
+++ b/utils/event-apis.js
@@ -104,10 +104,10 @@ export async function getAttendeeData(email, eventId) {
 export async function captureProfile() {
   try {
     const profile = await getProfile();
-    window.bm8tr.set('imsProfile', profile);
+    window.bm8r.set('imsProfile', profile);
   } catch {
     if (window.adobeIMS) {
-      window.bm8tr.set('imsProfile', { noProfile: true });
+      window.bm8r.set('imsProfile', { noProfile: true });
     }
   }
 }
@@ -126,12 +126,12 @@ function lazyCaptureProfile() {
 
     try {
       const profile = await getProfile();
-      window.bm8tr.set('imsProfile', profile);
+      window.bm8r.set('imsProfile', profile);
       clearInterval(profileRetryer);
     } catch {
       if (window.adobeIMS) {
         clearInterval(profileRetryer);
-        window.bm8tr.set('imsProfile', { noProfile: true });
+        window.bm8r.set('imsProfile', { noProfile: true });
       }
 
       attempCounter += 1;
@@ -159,7 +159,7 @@ export default async function fetchPageData(hash, lazyLoadProfile = false) {
     pageDataCache[hash] = pageData;
 
     if (lazyLoadProfile) lazyCaptureProfile();
-    window.bm8tr.set('eventData', pageData);
+    window.bm8r.set('eventData', pageData);
     return pageData;
   } catch (error) {
     window.lana?.log('Fetch error:', error);


### PR DESCRIPTION
Describe your specific features or fixes:
Moving up mediator, and switch it from dynamic import to static. Block Mediator was taking longer to load and autolinks was not setting the `bm8r.susbcribe`

Resolves: [MWPW-145669](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--events-milo--adobecom.hlx.page/drafts/cano/details-page
- After: https://MWPW-145669--events-milo--adobecom.hlx.page/drafts/cano/details-page
