### PR TITLE
stage.adobe.com redirect fix

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -322,6 +322,18 @@ function updateTextNode(child, matchCallback) {
   }
 }
 
+function updateTextContent(child, matchCallback) {
+  const originalText = child.textContent;
+  const replacedText = originalText.replace(
+    META_REG,
+    (_match, p1) => matchCallback(_match, p1, child),
+  );
+
+  if (replacedText !== originalText) {
+    child.textContent = replacedText;
+  }
+}
+
 function injectFragments(parent) {
   const productBlades = parent.querySelector('.event-product-blades');
 
@@ -449,19 +461,28 @@ export default function autoUpdateContent(parent, miloDeps, extraData) {
     return content;
   };
 
+  const isImage = (n) => n.tagName === 'IMG' && n.nodeType === 1;
+  const isTextNode = (n) => n.nodeType === 3;
+  const isStyledTextTag = (n) => n.tagName === 'STRONG' || n.tagName === 'EM';
+  const mightContainIcon = (n) => n.tagName === 'P' || n.tagName === 'A';
+
   const allElements = parent.querySelectorAll('*');
   allElements.forEach((element) => {
     if (element.childNodes.length) {
       element.childNodes.forEach((n) => {
-        if (n.tagName === 'IMG' && n.nodeType === 1) {
+        if (isImage(n)) {
           updateImgTag(n, getImgData, element);
         }
 
-        if (n.nodeType === 3) {
+        if (isTextNode(n)) {
           updateTextNode(n, getContent);
         }
 
-        if (n.tagName === 'P' || n.tagName === 'A') {
+        if (isStyledTextTag(n)) {
+          updateTextContent(n, getContent);
+        }
+
+        if (mightContainIcon(n)) {
           n.innerHTML = convertEccIcon(n);
         }
       });

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -125,9 +125,9 @@ export function validatePageAndRedirect() {
   const pagePublished = getMetadata('published') === 'true' || getMetadata('status') === 'live';
 
   const isUnpublishedOnProd = env === 'prod' && !pagePublished;
-  const isUnpublishedOnStageAdobeCom = env === 'stage' && window.location.hostname === 'www.stage.adobe.com' && !pagePublished;
+  const invalidStagePage = env === 'stage' && window.location.hostname === 'www.stage.adobe.com' && !getMetadata('event-id');
 
-  if (isUnpublishedOnProd || isUnpublishedOnStageAdobeCom) {
+  if (isUnpublishedOnProd || invalidStagePage) {
     window.location.replace('/404');
   }
 }

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -120,14 +120,14 @@ async function handleRSVPBtnBasedOnProfile(rsvpBtn, miloLibs, profile) {
   }
 }
 
-export async function validatePageAndRedirect() {
+export function validatePageAndRedirect() {
   const env = window.eccEnv;
-  const pagePublished = getMetadata('published') === 'true';
-  if (env === 'prod' && (!pagePublished)) {
-    window.location.replace('/404');
-  }
+  const pagePublished = getMetadata('published') === 'true' || getMetadata('status') === 'live';
 
-  if (env === 'stage' && window.location.hostname === 'www.stage.adobe.com') {
+  const isUnpublishedOnProd = env === 'prod' && !pagePublished;
+  const isUnpublishedOnStageAdobeCom = env === 'stage' && window.location.hostname === 'www.stage.adobe.com' && !pagePublished;
+
+  if (isUnpublishedOnProd || isUnpublishedOnStageAdobeCom) {
     window.location.replace('/404');
   }
 }

--- a/events/scripts/scripts.js
+++ b/events/scripts/scripts.js
@@ -91,11 +91,12 @@ export function decorateArea(area = document) {
 
   const photosData = parsePhotosData(area);
   const eventTitle = getMetadata('event-title') || document.title;
-  validatePageAndRedirect();
+
   const miloDeps = {
     miloLibs: LIBS,
     getConfig,
   };
+
   autoUpdateContent(area, miloDeps, {
     ...photosData,
     'event-title': eventTitle,
@@ -146,6 +147,8 @@ decorateArea();
 if (window.eccEnv !== 'prod' && !getMetadata('event-id') && getMetadata('event-details-page') === 'yes') {
   await fetchAndDecorateArea();
 }
+
+if (getMetadata('event-details-page') === 'yes') validatePageAndRedirect();
 
 /*
  * ------------------------------------------------------------


### PR DESCRIPTION
Fixes the issue where stage doesn't get a chance to populate metadata before redirect to 404 happens.
Fixes the issue where STRONG and EM tag placeholders can't be updated automatically

Test URLs:
- Before: https://dev--events-milo--adobecom.hlx.page/
- After: https://expand-content-replace--events-milo--adobecom.hlx.page/
