### PR TITLE
RSVP response consistency update

### DIFF
--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -134,7 +134,6 @@ function createButton({ type, label }, bp) {
         button.classList.remove('submitting');
         if (!respJson) {
           buildErrorMsg(bp.form);
-          window.lana?.log('Failed to submit RSVP form');
           return;
         }
 
@@ -330,7 +329,6 @@ function decorateSuccessMsg(form, bp) {
 
         if (!resp) {
           buildErrorMsg(bp.successMsg);
-          window.lana?.log('Failed to cancel RSVP');
           return;
         }
 

--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -100,10 +100,15 @@ function clearForm(form) {
   });
 }
 
-async function buildErrorMsg(form) {
+async function buildErrorMsg(parent) {
+  const existingErrors = parent.querySelectorAll('.error');
+  if (existingErrors.length) {
+    existingErrors.forEach((err) => err.remove());
+  }
+
   const errorMsg = await miloReplaceKey(LIBS, 'rsvp-error-msg');
   const error = createTag('p', { class: 'error' }, errorMsg);
-  form.append(error);
+  parent.append(error);
   setTimeout(() => {
     error.remove();
   }, 3000);
@@ -127,7 +132,7 @@ function createButton({ type, label }, bp) {
         const respJson = await submitForm(bp.form);
         button.removeAttribute('disabled');
         button.classList.remove('submitting');
-        if (respJson === null) {
+        if (!respJson) {
           buildErrorMsg(bp.form);
           window.lana?.log('Failed to submit RSVP form');
           return;
@@ -321,6 +326,14 @@ function decorateSuccessMsg(form, bp) {
 
       if (i === 0) {
         const resp = await deleteAttendee(getMetadata('event-id'));
+        cta.classList.remove('loading');
+
+        if (!resp) {
+          buildErrorMsg(bp.successMsg);
+          window.lana?.log('Failed to cancel RSVP');
+          return;
+        }
+
         BlockMediator.set('rsvpData', resp);
       }
 

--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -81,7 +81,7 @@ async function submitForm(form) {
   });
 
   let resp = null;
-  if (!rsvpData || !rsvpData.registered) {
+  if (!rsvpData || !rsvpData.status.registered) {
     resp = await createAttendee(getMetadata('event-id'), payload);
   } else {
     resp = await updateAttendee(getMetadata('event-id'), { ...rsvpData?.attendee, ...payload });
@@ -460,7 +460,7 @@ async function onProfile(bp, formData) {
     eventHero.classList.remove('loading');
     decorateHero(bp.eventHero);
     buildEventform(bp, formData).then(() => {
-      if (rsvpData?.registered) {
+      if (rsvpData?.status.registered) {
         showSuccessMsg(bp);
       } else {
         personalizeForm(block, profile);
@@ -475,7 +475,7 @@ async function onProfile(bp, formData) {
         eventHero.classList.remove('loading');
         decorateHero(bp.eventHero);
         buildEventform(bp, formData).then(() => {
-          if (rsvpData?.registered) {
+          if (rsvpData?.status.registered) {
             showSuccessMsg(bp);
           } else {
             personalizeForm(block, newValue);

--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -1,7 +1,7 @@
 import { LIBS } from '../../scripts/scripts.js';
 import { getMetadata } from '../../scripts/utils.js';
 import HtmlSanitizer from '../../scripts/deps/html-sanitizer.js';
-import { createAttendee, deleteAttendee, getAttendee, getAttendeeStatus, updateAttendee } from '../../scripts/esp-controller.js';
+import { createAttendee, deleteAttendee, updateAttendee } from '../../scripts/esp-controller.js';
 import BlockMediator from '../../scripts/deps/block-mediator.min.js';
 import { miloReplaceKey } from '../../scripts/content-update.js';
 

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -81,9 +81,9 @@ function createTag(tag, attributes, html, options = {}) {
 async function updateRSVPButtonState(rsvpBtn, miloLibs) {
   const rsvpData = BlockMediator.get('rsvpData');
   const checkRed = getIcon('check-circle-red');
-  if (rsvpData?.attendee?.attendeeId || (rsvpData?.action === 'create' && rsvpData?.resp?.status === 200)) {
+  if (rsvpData?.registered) {
     rsvpBtn.el.textContent = await miloReplaceKey(miloLibs, 'registered-cta-text');
-    rsvpBtn.prepend(checkRed);
+    rsvpBtn.el.prepend(checkRed);
   } else {
     rsvpBtn.el.textContent = rsvpBtn.originalText;
     checkRed.remove();

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -81,7 +81,7 @@ function createTag(tag, attributes, html, options = {}) {
 async function updateRSVPButtonState(rsvpBtn, miloLibs) {
   const rsvpData = BlockMediator.get('rsvpData');
   const checkRed = getIcon('check-circle-red');
-  if (rsvpData?.registered) {
+  if (rsvpData?.status.registered) {
     rsvpBtn.el.textContent = await miloReplaceKey(miloLibs, 'registered-cta-text');
     rsvpBtn.el.prepend(checkRed);
   } else {

--- a/events/scripts/esp-controller.js
+++ b/events/scripts/esp-controller.js
@@ -113,12 +113,12 @@ export async function getAttendeeStatus(eventId) {
 }
 
 export async function getCompleteAttendeeData(eventId) {
-  const [attendee, registered] = await Promise.all([
+  const [attendee, status] = await Promise.all([
     getAttendee(eventId),
     getAttendeeStatus(eventId),
   ]);
 
-  return { attendee, registered };
+  return { attendee, status };
 }
 
 export async function createAttendee(eventId, attendeeData) {
@@ -128,17 +128,13 @@ export async function createAttendee(eventId, attendeeData) {
   const raw = JSON.stringify(attendeeData);
   const options = await constructRequestOptions('POST', raw);
 
-  const resp = await fetch(`${host}/v1/events/${eventId}/attendees`, options)
+  await fetch(`${host}/v1/events/${eventId}/attendees`, options)
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to create attendee for event ${eventId}. Error: ${error}`));
 
   // FIXME: create attendee doesn't respond with attendee data
-  if (!resp || (resp && !(resp.errors || resp.messages))) {
-    const rsvpData = await getCompleteAttendeeData(eventId);
-    return rsvpData;
-  }
-
-  return null;
+  const rsvpData = await getCompleteAttendeeData(eventId);
+  return rsvpData;
 }
 
 export async function updateAttendee(eventId, attendeeData) {
@@ -148,18 +144,14 @@ export async function updateAttendee(eventId, attendeeData) {
   const raw = JSON.stringify(attendeeData);
   const options = await constructRequestOptions('PUT', raw);
 
-  const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
+  await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to update attendee me for event ${eventId}. Error: ${error}`));
 
   // FIXME: update attendee doesn't update attendee data.
   // instead, it actually strips the previously submitted data and returns only the basic info
-  if (resp && !(resp.errors || resp.messages)) {
-    const rsvpData = await getCompleteAttendeeData(eventId);
-    return rsvpData;
-  }
-
-  return null;
+  const rsvpData = await getCompleteAttendeeData(eventId);
+  return rsvpData;
 }
 
 export async function deleteAttendee(eventId) {
@@ -168,16 +160,12 @@ export async function deleteAttendee(eventId) {
   const { host } = getAPIConfig().esl[window.eccEnv];
   const options = await constructRequestOptions('DELETE');
 
-  const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
+  await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to delete attendee me for event ${eventId}. Error: ${error}`));
 
-  if (resp && resp.status === 204) {
-    const rsvpData = await getCompleteAttendeeData(eventId);
-    return rsvpData;
-  }
-
-  return null;
+  const rsvpData = await getCompleteAttendeeData(eventId);
+  return rsvpData;
 }
 
 export async function getAttendees(eventId) {

--- a/events/scripts/esp-controller.js
+++ b/events/scripts/esp-controller.js
@@ -128,9 +128,13 @@ export async function createAttendee(eventId, attendeeData) {
   const raw = JSON.stringify(attendeeData);
   const options = await constructRequestOptions('POST', raw);
 
-  await fetch(`${host}/v1/events/${eventId}/attendees`, options)
+  const resp = await fetch(`${host}/v1/events/${eventId}/attendees`, options)
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to create attendee for event ${eventId}. Error: ${error}`));
+
+  if (!resp || resp.errors || resp.message) {
+    return false;
+  }
 
   // FIXME: create attendee doesn't respond with attendee data
   const rsvpData = await getCompleteAttendeeData(eventId);
@@ -144,10 +148,13 @@ export async function updateAttendee(eventId, attendeeData) {
   const raw = JSON.stringify(attendeeData);
   const options = await constructRequestOptions('PUT', raw);
 
-  await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
+  const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to update attendee me for event ${eventId}. Error: ${error}`));
 
+  if (!resp || resp.errors || resp.message) {
+    return false;
+  }
   // FIXME: update attendee doesn't update attendee data.
   // instead, it actually strips the previously submitted data and returns only the basic info
   const rsvpData = await getCompleteAttendeeData(eventId);
@@ -160,9 +167,13 @@ export async function deleteAttendee(eventId) {
   const { host } = getAPIConfig().esl[window.eccEnv];
   const options = await constructRequestOptions('DELETE');
 
-  await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
+  const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to delete attendee me for event ${eventId}. Error: ${error}`));
+
+  if (!resp || resp.errors || resp.message) {
+    return false;
+  }
 
   const rsvpData = await getCompleteAttendeeData(eventId);
   return rsvpData;

--- a/events/scripts/profile.js
+++ b/events/scripts/profile.js
@@ -1,5 +1,5 @@
 import BlockMediator from './deps/block-mediator.min.js';
-import { getAttendee } from './esp-controller.js';
+import { getAttendee, getCompleteAttendeeData } from './esp-controller.js';
 import { getMetadata } from './utils.js';
 
 export async function getProfile() {
@@ -38,13 +38,13 @@ export function lazyCaptureProfile() {
     try {
       const [profile, rsvpData] = await Promise.all([
         getProfile(),
-        getAttendee(getMetadata('event-id')),
+        getCompleteAttendeeData(getMetadata('event-id')),
       ]);
 
       if (rsvpData) {
-        BlockMediator.set('rsvpData', { attendee: rsvpData });
+        BlockMediator.set('rsvpData', rsvpData);
       } else {
-        BlockMediator.set('rsvpData', { attendee: null });
+        BlockMediator.set('rsvpData', null);
       }
 
       BlockMediator.set('imsProfile', profile);

--- a/events/scripts/profile.js
+++ b/events/scripts/profile.js
@@ -1,5 +1,5 @@
 import BlockMediator from './deps/block-mediator.min.js';
-import { getAttendee, getCompleteAttendeeData } from './esp-controller.js';
+import { getCompleteAttendeeData } from './esp-controller.js';
 import { getMetadata } from './utils.js';
 
 export async function getProfile() {


### PR DESCRIPTION
Changes RSVP flow to use extra calls to get consistent rsvpData in BlockMediator. This is leveraging the new attendees/me/status endpoint Todd has enabled for us.

Resolves: [MWPW-148336](https://jira.corp.adobe.com/browse/MWPW-148336)

Test URLs:
- Before: https://dev--events-milo--adobecom.hlx.page/events/create-now/create-now-chicago-2024/chicago/il/2024-08-04?martech=off
- After: https://rsvp-update--events-milo--adobecom.hlx.page/events/create-now/create-now-chicago-2024/chicago/il/2024-08-04?martech=off
