### PR TITLE
preview bar fix and a rogue console error fix

### DIFF
--- a/events/blocks/preview-bar/preview-bar.js
+++ b/events/blocks/preview-bar/preview-bar.js
@@ -14,7 +14,7 @@ function removeURLParameter(url, parameter) {
 }
 
 function getEventStatus() {
-  const publishedMeta = getMetadata('published')?.toLowerCase() !== 'true' || getMetadata('status')?.toLowerCase() === 'live';
+  const publishedMeta = getMetadata('published')?.toLowerCase() === 'true' || getMetadata('status')?.toLowerCase() === 'live';
   const dot = publishedMeta ? getIcon('dot-purple') : getIcon('dot-green');
   const text = publishedMeta ? 'Published' : 'Draft';
 

--- a/events/scripts/esp-controller.js
+++ b/events/scripts/esp-controller.js
@@ -94,10 +94,13 @@ export async function getAttendee(eventId) {
   const { host } = getAPIConfig().esl[window.eccEnv];
   const options = await constructRequestOptions('GET');
 
-  const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me`, options)
-    .then((res) => res.json())
-    .catch((error) => window.lana?.log(`Failed to get details of attendee me for event ${eventId}. Error: ${error}`));
-  return resp;
+  const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me`, options);
+
+  if (resp.status === 404) {
+    return null;
+  }
+
+  return resp.json();
 }
 
 export async function getAttendeeStatus(eventId) {
@@ -108,7 +111,7 @@ export async function getAttendeeStatus(eventId) {
 
   const resp = await fetch(`${host}/v1/events/${eventId}/attendees/me/status`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log(`Failed to get details of attendee me for event ${eventId}. Error: ${error}`));
+    .catch((error) => window.lana?.log(`Failed to get status of attendee me for event ${eventId}. Error: ${error}`));
   return resp;
 }
 


### PR DESCRIPTION
Fixing a wrong bool output from the preview bar condition check
Fixes a false negative console error caused by attendee fetch

Resolves: Pending [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
Or we can refer to this one: [MWPW-153776](https://jira.corp.adobe.com/browse/MWPW-153776)

Test URLs:
- Before: https://dev--events-milo--adobecom.hlx.page/
- After: https://preview-bar-fix--events-milo--adobecom.hlx.page/
