### PR TITLE
Adobe IMSProfile based preview hotfix

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -150,13 +150,14 @@ export async function validatePageAndRedirect() {
   }
 
   if (purposefulHitOnProdPreview) {
-    await waitForAdobeIMS();
-    const profile = await getProfile();
-    if (profile?.noProfile) {
-      signIn();
-    } else if (!profile.email.endsWith('@adobe.com')) {
-      window.location.replace('/404');
-    }
+    waitForAdobeIMS().then(async () => {
+      const profile = await getProfile();
+      if (profile?.noProfile) {
+        signIn();
+      } else if (!profile.email.endsWith('@adobe.com')) {
+        window.location.replace('/404');
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Resolves: no ticket
Once this is merged, https://main--events-milo--adobecom.hlx.page/events/create-now/test-event-pd/pleasant-grove/ut/2024-08-16?previewMode=true should show the page while https://main--events-milo--adobecom.hlx.page/events/create-now/test-event-pd/pleasant-grove/ut/2024-08-16 should redirect to 404
Test URLs:

- Before: https://dev--events-milo--adobecom.hlx.page/
- After: https://preview-hotfix--events-milo--adobecom.hlx.page/
