### PR TITLE
Add form view and form submission analytics

### DIFF
--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -123,6 +123,16 @@ function showSuccessMsg(bp) {
   bp.successMsg.classList.remove('hidden');
 }
 
+function eventFormSendAnalytics(bp, view) {
+  const modal = bp.block.closest('.dialog-modal');
+  if (!modal) return;
+  const title = getMetadata('event-title');
+  const name = title ? ` | ${title}` : '';
+  const modalId = modal?.id ? ` | ${modal?.id}` : '';
+  const event = new Event(`${view}${name}${modalId}`);
+  sendAnalytics(event);
+}
+
 function createButton({ type, label }, bp) {
   const button = createTag('button', { class: 'button' }, label);
   if (type === 'submit') {
@@ -136,7 +146,7 @@ function createButton({ type, label }, bp) {
         button.classList.remove('submitting');
         if (!respJson) return;
 
-        if (respJson.ok) eventFormSendAnalytics(bp,'Form Submit');
+        if (respJson.ok) eventFormSendAnalytics(bp, 'Form Submit');
         BlockMediator.set('rsvpData', respJson);
         if (!respJson.ok || respJson.error) {
           let { status } = respJson;
@@ -496,15 +506,6 @@ async function buildEventform(bp, formData) {
   }
 }
 
-function eventFormSendAnalytics(bp,view) {
-  if (bp.modal) {
-    const title = bp?.title?.textContent?.trim();
-    const name = title ? ` | ${title}` : '';
-    const modalId = bp?.modal?.id ? ` | ${bp?.modal?.id}` : '';
-    const event = new Event(`${view}${name}${modalId}`);
-    sendAnalytics(event);
-  }
-}
 function initFormBasedOnRSVPData(bp) {
   const { block } = bp;
   const profile = BlockMediator.get('imsProfile');
@@ -520,7 +521,7 @@ function initFormBasedOnRSVPData(bp) {
       showSuccessMsg(bp);
     }
   });
- eventFormSendAnalytics(bp,'Form View');
+  eventFormSendAnalytics(bp, 'Form View');
 }
 
 async function onProfile(bp, formData) {
@@ -576,8 +577,6 @@ export default async function decorate(block, formData = null) {
     form: block.querySelector(':scope > div:nth-of-type(2) a[href$=".json"]'),
     terms: block.querySelector(':scope > div:nth-of-type(3)'),
     successMsg: block.querySelector(':scope > div:last-of-type > div'),
-    title: block.querySelector(':scope #event-title'),
-    modal: block.closest('.dialog-modal'),
   };
 
   await onProfile(bp, formData);

--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -128,7 +128,7 @@ function eventFormSendAnalytics(bp, view) {
   if (!modal) return;
   const title = getMetadata('event-title');
   const name = title ? ` | ${title}` : '';
-  const modalId = modal?.id ? ` | ${modal?.id}` : '';
+  const modalId = modal.id ? ` | ${modal.id}` : '';
   const event = new Event(`${view}${name}${modalId}`);
   sendAnalytics(event);
 }

--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -146,9 +146,8 @@ function createButton({ type, label }, bp) {
         button.classList.remove('submitting');
         if (!respJson) return;
 
-        if (respJson.ok) eventFormSendAnalytics(bp, 'Form Submit');
         BlockMediator.set('rsvpData', respJson);
-        if (!respJson.ok || respJson.error) {
+        if (respJson.error) {
           let { status } = respJson;
 
           // FIXME: temporary fix for ESL 500 on ESP 400
@@ -159,6 +158,7 @@ function createButton({ type, label }, bp) {
           }
           buildErrorMsg(bp.form, status);
         }
+        if (respJson.ok !== false && !respJson.error) eventFormSendAnalytics(bp, 'Form Submit');
       }
     });
   }


### PR DESCRIPTION
Adds additional analytics to events-form on "Form View" and "Form Submission" 
To QA, use this [link](https://dev--events-milo--adobecom.hlx.page/events/create-now/create-now-chicago-2024-test/chicago/il/2024-07-27?timing=123 ) override the events-form.js code in browser (will need to click on "RSVP now" button once to get file to load). Type  _satellite.setDebug(true) in the console and then click the rsvp button. 

Look through the debugger data objects in the console to find new analytics name under web, webInteraction, linkClicks, name:
![Screenshot 2024-08-29 at 12 20 19 PM](https://github.com/user-attachments/assets/25efdb52-2859-4b2d-a266-43668bb6e611)

You should also see "Form Submission | Create Now Chicago 2024 Test | rsvp-form-1" if you click on the button to submit the form. 
Resolves: [MWPW-156794](https://jira.corp.adobe.com/browse/MWPW-156794)

Test URLs:
- Before: https://main--events-milo--adobecom.hlx.page/
- After: https://addformanalytics--events-milo--adobecom.hlx.page/
