### PR TITLE
[MWPW-157576] no longer change URL when bar removed

### DIFF
--- a/events/blocks/preview-bar/preview-bar.js
+++ b/events/blocks/preview-bar/preview-bar.js
@@ -3,16 +3,6 @@ import { getIcon } from '../../scripts/utils.js';
 
 const { createTag, getMetadata } = await import(`${LIBS}/utils/utils.js`);
 
-function removeURLParameters(url, parameters) {
-  const params = new URLSearchParams(url.search);
-
-  if (Array.isArray(parameters)) parameters.forEach((p) => params.delete(p));
-
-  url.search = params.toString();
-
-  return url.toString();
-}
-
 function getEventStatus() {
   const publishedMeta = getMetadata('published')?.toLowerCase() === 'true' || getMetadata('status')?.toLowerCase() === 'live';
   const dot = publishedMeta ? getIcon('dot-purple') : getIcon('dot-green');
@@ -40,7 +30,6 @@ function getCloseBtn(el) {
 
   btn.addEventListener('click', () => {
     el.remove();
-    removeURLParameters(window.location, ['previewMode', 'cacheBuster']);
   });
 
   return btn;


### PR DESCRIPTION
Resolves: [MWPW-157576](https://jira.corp.adobe.com/browse/MWPW-157576)

Test URLs:
- Before: https://dev--events-milo--adobecom.hlx.page/events/create-now/embrace-generative-ai-sep02/midvale/ut/2024-09-20?previewMode=true&cachebuster=1725391549880&timing=1726849799990
- After: https://MWPW-157576--events-milo--adobecom.hlx.page/events/create-now/embrace-generative-ai-sep02/midvale/ut/2024-09-20?previewMode=true&cachebuster=1725391549880&timing=1726849799990
