### PR TITLE
[Hotfix] Less false positive in link detection logic

### DIFF
--- a/events/blocks/profile-cards/profile-cards.js
+++ b/events/blocks/profile-cards/profile-cards.js
@@ -68,10 +68,20 @@ async function decorateSocialIcons(cardContainer, socialLinks) {
 
   const svgEls = await getSVGsfromFile(svgPath, SUPPORTED_SOCIAL);
   if (!svgEls || svgEls.length === 0) return;
-
   socialLinks.forEach((social) => {
     const { link } = social;
-    const platform = SUPPORTED_SOCIAL.find((p) => link.toLowerCase().includes(p)) || 'web';
+
+    if (!link) return;
+
+    let platform = '';
+    try {
+      const url = new URL(link);
+      const hostname = url.hostname.toLowerCase();
+      platform = SUPPORTED_SOCIAL.find((p) => hostname.includes(`${p}.`)) || 'web';
+    } catch (error) {
+      platform = 'web';
+    }
+
     const svgEl = svgEls.find((el) => el.name === platform);
     if (!svgEl) return;
 


### PR DESCRIPTION
Tightens the detection logic to look for "<platform-name>." in only the hostname
Resolves: [MWPW-161959](https://jira.corp.adobe.com/browse/MWPW-161959)

Test URLs:
https://www.adobe.com/events/creative-jam/creative-jam-phoenix/phoenix/az/2024-11-12.html

Can't be tested on different environments. You can use browser override and replace the events/blocks/profile-cards/profile-cards.js with the new version on this branch.