### PR TITLE
[CSS Tweak] Add a small padding to avoid block collision

### DIFF
--- a/events/blocks/event-map/event-map.css
+++ b/events/blocks/event-map/event-map.css
@@ -2,7 +2,7 @@
   max-width: 1750px;
   margin: auto;
   box-sizing: content-box;
-  padding: 32px 20px 0;
+  padding: 32px 20px 20px;
 }
 
 .event-map h2 {


### PR DESCRIPTION
Added a small padding to avoid mobile block collision when speakers are missing

Resolves: [MWPW-164922](https://jira.corp.adobe.com/browse/MWPW-164922)

Test URLs:
- Before: https://dev--events-milo--adobecom.hlx.page/
- After: https://jan-8-qa-fixes--events-milo--adobecom.hlx.page/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
