### PR TITLE
[Dev -> Stage] Parse URL before trying to find non-prod data (#216)

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -469,7 +469,17 @@ export async function getNonProdData(env) {
     const json = await resp.json();
     let { pathname } = window.location;
     if (pathname.endsWith('.html')) pathname = pathname.slice(0, -5);
-    const pageData = json.data.find((d) => d.url === pathname);
+    const pageData = json.data.find((d) => {
+      let pageUrl = '';
+
+      try {
+        pageUrl = new URL(d.url).pathname;
+      } catch (e) {
+        pageUrl = d.url;
+      }
+
+      return pageUrl === pathname;
+    });
 
     if (pageData) return pageData;
 


### PR DESCRIPTION
Test URLs:
- Before: https://stage--events-milo--adobecom.hlx.page/
- After: https://dev--events-milo--adobecom.hlx.page/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
