### PR TITLE
Change deleteAttendee call response handling

### DIFF
--- a/events/scripts/esp-controller.js
+++ b/events/scripts/esp-controller.js
@@ -261,6 +261,7 @@ export async function deleteAttendeeFromEvent(eventId) {
       };
     }
 
+    if (response.status === 204) return { ok: true, data: { status: 204, attendeeDeleted: true } };
     return { ok: true, data: await response.json() };
   } catch (error) {
     window.lana?.log(`Error: Failed to delete attendee for event ${eventId}:`, error);


### PR DESCRIPTION
deleteAttendee call now expects empty response. Only the helper fetcher is changed. The block is expecting the same data.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--events-milo--adobecom.hlx.page/
- After: https://MWPW-165501--events-milo--adobecom.hlx.page/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
