### PR TITLE
Dev -> Stage Jan 13th

### DIFF
--- a/events/blocks/event-map/event-map.css
+++ b/events/blocks/event-map/event-map.css
@@ -2,7 +2,7 @@
   max-width: 1750px;
   margin: auto;
   box-sizing: content-box;
-  padding: 32px 20px 0;
+  padding: 32px 20px 20px;
 }
 
 .event-map h2 {

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -469,7 +469,17 @@ export async function getNonProdData(env) {
     const json = await resp.json();
     let { pathname } = window.location;
     if (pathname.endsWith('.html')) pathname = pathname.slice(0, -5);
-    const pageData = json.data.find((d) => d.url === pathname);
+    const pageData = json.data.find((d) => {
+      let pageUrl = '';
+
+      try {
+        pageUrl = new URL(d.url).pathname;
+      } catch (e) {
+        pageUrl = d.url;
+      }
+
+      return pageUrl === pathname;
+    });
 
     if (pageData) return pageData;
 


### PR DESCRIPTION
- Added helix-query change for consent string fragments
- Added response change handling for deleteAttendee call

Test URLs:
- Before: https://stage--events-milo--adobecom.hlx.page/
- After: https://dev--events-milo--adobecom.hlx.page/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
