### PR TITLE
[MWPW-166938] Use templateID as fallback while prioritising series data

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -283,7 +283,19 @@ function autoUpdateLinks(scope, miloLibs) {
       if (/#rsvp-form.*/.test(a.href)) {
         handleRegisterButton(a, miloLibs);
       } else if (a.href.endsWith('#event-template')) {
-        if (getMetadata('template-id')) {
+        let templateId;
+
+        try {
+          const series = JSON.parse(getMetadata('series'));
+          templateId = series?.templateId;
+        } catch (e) {
+          window.lana?.log('Failed to parse series metadata. Attempt to fallback on event tempate ID attribute:', e);
+          if (getMetadata('template-id')) {
+            templateId = getMetadata('template-id');
+          }
+        }
+
+        if (templateId) {
           const params = new URLSearchParams(document.location.search);
           const testTiming = params.get('timing');
           let timeSuffix = '';
@@ -296,9 +308,11 @@ function autoUpdateLinks(scope, miloLibs) {
             timeSuffix = currentTimestamp > +getMetadata('local-end-time-millis') ? '-post' : '-pre';
           }
 
-          a.href = `${getMetadata('template-id')}${timeSuffix}`;
+          a.href = `${templateId}${timeSuffix}`;
           const timingClass = `timing${timeSuffix}-event`;
           document.body.classList.add(timingClass);
+        } else {
+          window.lana?.log(`Error: Failed to find template ID for event ${getMetadata('event-id')}`);
         }
       } else if (a.href.endsWith('#host-email')) {
         if (getMetadata('host-email')) {


### PR DESCRIPTION
Resolves: [MWPW-166938](https://jira.corp.adobe.com/browse/MWPW-166938)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://use-series-data--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
