### PR TITLE
Fix guest registration attr key for Consent loading

### DIFF
--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -757,7 +757,7 @@ async function createForm(bp, formData) {
   });
 
   addTerms(formEl, terms);
-  if (!getMetadata('login-required')) await addConsentSuite(formEl);
+  if (getMetadata('allow-guest-registration') === 'true') await addConsentSuite(formEl);
 
   formEl.addEventListener('input', () => applyRules(formEl, rules));
   applyRules(formEl, rules);


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://consent-only-for-guest--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
