### PR TITLE
Adding block self-destruct upon JSON parse failure

### DIFF
--- a/events/blocks/event-map/event-map.js
+++ b/events/blocks/event-map/event-map.js
@@ -16,9 +16,18 @@ function decorateTextContainer(el, createTag, decorateButtons) {
     p.remove();
   });
 
-  const venueObj = JSON.parse(getMetadata('venue'));
+  let venueObj;
 
-  if (!venueObj) return;
+  try {
+    venueObj = JSON.parse(getMetadata('venue'));
+  } catch (e) {
+    window.lana?.log('Error while parsing venue metadata:', e);
+  }
+
+  if (!venueObj) {
+    el.remove();
+    return;
+  }
 
   const { formattedAddress, venueName, additionalInformation } = venueObj;
 

--- a/events/blocks/profile-cards/profile-cards.js
+++ b/events/blocks/profile-cards/profile-cards.js
@@ -166,6 +166,7 @@ export default function init(el) {
     data = JSON.parse(getMetadata('speakers'));
   } catch (error) {
     window.lana?.log('Failed to parse speakers metadata:', error);
+    el.remove();
     return;
   }
 


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://try-catch-blocks--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
