### PR TITLE
[Hotfix] Template ID Regression

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -272,9 +272,10 @@ function autoUpdateLinks(scope, miloLibs) {
           templateId = series?.templateId;
         } catch (e) {
           window.lana?.log('Failed to parse series metadata. Attempt to fallback on event tempate ID attribute:', e);
-          if (getMetadata('template-id')) {
-            templateId = getMetadata('template-id');
-          }
+        }
+
+        if (!templateId && getMetadata('template-id')) {
+          templateId = getMetadata('template-id');
         }
 
         if (templateId) {


### PR DESCRIPTION
Test URLs:
- Before: https://main--events-milo--adobecom.aem.live/drafts/
- After: https://template-id-hotfix--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
