### PR TITLE
[HOTFIX] Fixing an issue with RSVP button when event is full and the user has already registered

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -71,6 +71,8 @@ function convertEccIcon(n) {
 
 async function setCtaState(targetState, rsvpBtn, miloLibs) {
   const checkRed = getIcon('check-circle-red');
+  const btnHref = rsvpBtn.el.href;
+
   const enableBtn = () => {
     rsvpBtn.el.classList.remove('disabled');
     rsvpBtn.el.setAttribute('tabindex', 0);
@@ -78,7 +80,7 @@ async function setCtaState(targetState, rsvpBtn, miloLibs) {
 
   const disableBtn = () => {
     rsvpBtn.el.setAttribute('tabindex', -1);
-    rsvpBtn.el.href = '';
+    rsvpBtn.el.href = btnHref;
     rsvpBtn.el.classList.add('disabled');
   };
 


### PR DESCRIPTION
Test URLs:
- Before: https://main--events-milo--adobecom.aem.live/drafts/
- After: https://rsvp-hot-fix--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
