### PR TITLE
Adding disctionary manager to localize RSVP fields

### DIFF
--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -2,8 +2,9 @@ import { LIBS, getMetadata, getSusiOptions } from '../../scripts/utils.js';
 import { deleteAttendeeFromEvent, getAndCreateAndAddAttendee, getAttendee, getEvent } from '../../scripts/esp-controller.js';
 import BlockMediator from '../../scripts/deps/block-mediator.min.js';
 import { miloReplaceKey, signIn } from '../../scripts/content-update.js';
+import { dictionaryManager } from '../../scripts/dictionary-manager.js';
 
-const { createTag } = await import(`${LIBS}/utils/utils.js`);
+const { createTag, getConfig } = await import(`${LIBS}/utils/utils.js`);
 const { closeModal, sendAnalytics } = await import(`${LIBS}/blocks/modal/modal.js`);
 const { default: sanitizeComment } = await import(`${LIBS}/utils/sanitizeComment.js`);
 const { decorateDefaultLinkAnalytics } = await import(`${LIBS}/martech/attributes.js`);
@@ -27,15 +28,17 @@ function snakeToCamel(str) {
     .join('');
 }
 
-function createSelect(params) {
+function createSelect(fd) {
   const {
     field, placeholder, options, defval, required, type,
-  } = params;
+  } = fd;
+
   const select = createTag('select', { id: field });
-  if (placeholder) select.append(createTag('option', { class: 'placeholder-option', selected: '', disabled: '', value: '' }, placeholder));
-  options.split(';').forEach((o) => {
+  if (placeholder) select.append(createTag('option', { class: 'placeholder-option', selected: '', disabled: '', value: '' }, dictionaryManager.getValue(placeholder)));
+  options.split(';').forEach(async (o) => {
     const text = o.trim();
-    const option = createTag('option', { value: text }, text);
+    const optionText = dictionaryManager.getValue(text);
+    const option = createTag('option', { value: text }, optionText);
     select.append(option);
     if (defval === text) select.value = text;
   });
@@ -77,7 +80,7 @@ function createSelect(params) {
 
     options.split(';').forEach((o) => {
       const text = o.trim();
-      const label = createTag('label', {}, text, { parent: customDropdown });
+      const label = createTag('label', {}, dictionaryManager.getValue(text), { parent: customDropdown });
       createTag('input', { type: 'checkbox', value: text, class: 'no-submit' }, '', { parent: label });
     });
 
@@ -247,7 +250,7 @@ function eventFormSendAnalytics(bp, view) {
 }
 
 function createButton({ type, label }, bp) {
-  const button = createTag('button', { class: 'button' }, label);
+  const button = createTag('button', { class: 'button' }, dictionaryManager.getValue(label));
   if (type === 'submit') {
     button.addEventListener('click', async (event) => {
       if (bp.form.checkValidity()) {
@@ -303,7 +306,7 @@ function createButton({ type, label }, bp) {
 }
 
 function createHeading({ label }, el) {
-  return createTag(el, {}, label);
+  return createTag(el, {}, dictionaryManager.getValue(label));
 }
 
 function createInput({ type, field, placeholder, required, defval }) {
@@ -319,7 +322,7 @@ function createTextArea({ field, placeholder, required, defval }) {
 }
 
 function createlabel({ field, label, required }) {
-  return createTag('label', { for: field, class: required ? 'required' : '' }, label);
+  return createTag('label', { for: field, class: required ? 'required' : '' }, dictionaryManager.getValue(label));
 }
 
 function createCheckItem(item, type, id, def) {
@@ -327,7 +330,7 @@ function createCheckItem(item, type, id, def) {
   const defList = def.split(';').map((defItem) => defItem.trim());
   const pseudoEl = createTag('span', { class: `check-item-button ${type}-button` });
   const [customLabel, customVal] = item.split('::');
-  const label = createTag('label', { class: `check-item-label ${type}-label`, for: `${id}-${itemKebab}` }, customLabel || item);
+  const label = createTag('label', { class: `check-item-label ${type}-label`, for: `${id}-${itemKebab}` }, dictionaryManager.getValue(customLabel) || item);
   const input = createTag(
     'input',
     { type, name: id, value: customVal || item, class: `check-item-input ${type}-input`, id: `${id}-${itemKebab}` },
@@ -695,6 +698,12 @@ async function createForm(bp, formData) {
     json = await resp.json();
   }
 
+  const config = getConfig();
+  await dictionaryManager.fetchDictionary({
+    config,
+    sheet: 'rsvp-fields',
+  });
+
   if (rsvpFieldsData) {
     const { required, visible } = rsvpFieldsData;
     json.data = json.data
@@ -720,7 +729,7 @@ async function createForm(bp, formData) {
 
   const typeToElement = {
     'multi-select': { fn: createSelect, params: [], label: true, classes: [] },
-    select: { fn: createSelect, params: [], label: true, classes: [] },
+    select: { fn: createSelect, params: ['something'], label: true, classes: [] },
     heading: { fn: createHeading, params: ['h3'], label: false, classes: [] },
     legal: { fn: createHeading, params: ['p'], label: false, classes: [] },
     checkbox: { fn: createCheckGroup, params: ['checkbox'], label: true, classes: ['field-group-wrapper'] },
@@ -735,7 +744,7 @@ async function createForm(bp, formData) {
 
   const sanitizeList = [];
 
-  json.data.forEach((fd) => {
+  json.data.forEach(async (fd) => {
     fd.type = fd.type || 'text';
     if (fd.type === 'text') sanitizeList.push(fd.field);
     const style = fd.extra ? ` events-form-${fd.extra}` : '';
@@ -876,7 +885,7 @@ async function initFormBasedOnRSVPData(bp) {
       }
     } else {
       const countryInNavigator = window.navigator.language.toLowerCase().split('-')[1];
-      const option = options.find((o) => {
+      const option = options.find(async (o) => {
         const countryCode = o.dataset.countryCode?.toLowerCase();
 
         if (!countryCode) return false;
@@ -906,7 +915,6 @@ async function initFormBasedOnRSVPData(bp) {
 async function onProfile(bp, formData) {
   const { block, eventHero } = bp;
   const profile = BlockMediator.get('imsProfile');
-  const { getConfig } = await import(`${LIBS}/utils/utils.js`);
   const allowGuestReg = getMetadata('allow-guest-registration') === 'true';
   if (profile) {
     if ((profile.noProfile || profile.account_type === 'guest')

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -15,7 +15,7 @@ const preserveFormatKeys = [
   'description',
 ];
 
-export async function miloReplaceKey(miloLibs, key) {
+export async function miloReplaceKey(miloLibs, key, sheetName) {
   try {
     const [utils, placeholders] = await Promise.all([
       import(`${miloLibs}/utils/utils.js`),
@@ -26,7 +26,7 @@ export async function miloReplaceKey(miloLibs, key) {
     const { replaceKey } = placeholders;
     const config = getConfig();
 
-    return await replaceKey(key, config);
+    return await replaceKey(key, config, sheetName);
   } catch (error) {
     window.lana?.log(`Error trying to replace placeholder:\n${JSON.stringify(error, null, 2)}`);
     return key;

--- a/events/scripts/dictionary-manager.js
+++ b/events/scripts/dictionary-manager.js
@@ -1,0 +1,33 @@
+export class DictionaryManager {
+  #dictionary = {};
+
+  static getPlaceholdersPath(config, sheet) {
+    const path = `${config.locale.contentRoot}/placeholders.json`;
+    const query = sheet !== 'default' && typeof sheet === 'string' && sheet.length ? `?sheet=${sheet}` : '';
+    return `${path}${query}`;
+  }
+
+  async fetchDictionary({ config, sheet }) {
+    try {
+      const path = DictionaryManager.getPlaceholdersPath(config, sheet);
+      const response = await fetch(path);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch dictionary: ${response.status}`);
+      }
+      const data = await response.json();
+      this.#dictionary = Object.freeze(data.data.reduce((acc, item) => {
+        acc[item.key] = item.value;
+        return acc;
+      }, {}));
+    } catch (error) {
+      window.lana?.log(`Error fetching dictionary:\n${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
+  getValue(key) {
+    return this.#dictionary[key] || key;
+  }
+}
+
+export const dictionaryManager = new DictionaryManager();


### PR DESCRIPTION
Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
