### PR TITLE
Update placeholder with translation too

### DIFF
--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -310,13 +310,15 @@ function createHeading({ label }, el) {
 }
 
 function createInput({ type, field, placeholder, required, defval }) {
-  const input = createTag('input', { type, id: field, placeholder, value: defval });
+  const placeholderText = placeholder ? dictionaryManager.getValue(placeholder) : '';
+  const input = createTag('input', { type, id: field, placeholder: placeholderText, value: defval });
   if (required === 'x') input.setAttribute('required', 'required');
   return input;
 }
 
 function createTextArea({ field, placeholder, required, defval }) {
-  const input = createTag('textarea', { id: field, placeholder, value: defval });
+  const placeholderText = placeholder ? dictionaryManager.getValue(placeholder) : '';
+  const input = createTag('textarea', { id: field, placeholder: placeholderText, value: defval });
   if (required === 'x') input.setAttribute('required', 'required');
   return input;
 }


### PR DESCRIPTION
The ESP RSVP form is not loading dictionary values in the placeholders. This PR should fix that.

Before:
<img width="869" alt="Screenshot 2025-05-09 at 4 55 45 PM" src="https://github.com/user-attachments/assets/0b5b8ecb-d4fb-4b67-b256-c9e8df4acac8" />

After:
<img width="812" alt="Screenshot 2025-05-09 at 4 55 22 PM" src="https://github.com/user-attachments/assets/332f7da6-6e98-4c0d-9690-3ff7e3e4f612" />


Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://dictionary-placeholder--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
