### PR TITLE
Add sitemap config for added locales

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -32,3 +32,29 @@ indices:
     include:
       - '/de/events/**'
     target: /de/events/query-index.xlsx
+
+  fr:
+    <<: *website
+    include:
+      - '/fr/events/**'
+    target: /fr/events/query-index.xlsx
+
+  uk:
+    <<: *website
+    include:
+      - '/uk/events/**'
+    target: /uk/events/query-index.xlsx
+
+  es:
+    <<: *website
+    include:
+      - '/es/events/**'
+    target: /es/events/query-index.xlsx
+
+  th_en:
+    <<: *website
+    include:
+      - '/th_en/events/**'
+    target: /th_en/events/query-index.xlsx
+
+  

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -13,6 +13,21 @@ sitemaps:
         destination: /de/events/create-now/sitemap.xml
         hreflang: de
         alternate: /{path}
+      fr:
+        source: /fr/events/query-index.json
+        destination: /fr/events/create-now/sitemap.xml
+        hreflang: fr
+        alternate: /{path}
+      es:
+        source: /es/events/query-index.json
+        destination: /es/events/create-now/sitemap.xml
+        hreflang: es
+        alternate: /{path}
+      th_en:
+        source: /th_en/events/query-index.json
+        destination: /th_en/events/create-now/sitemap.xml
+        hreflang: th
+        alternate: /{path}
   
   seo-templates:
     origin: https://www.adobe.com
@@ -26,4 +41,19 @@ sitemaps:
         source: /de/events/default/metadata.json?sheet=sitemap
         destination: /de/events/create-now/events-sitemap.xml
         hreflang: de
+        alternate: /{path}
+      fr:
+        source: /fr/events/default/metadata.json?sheet=sitemap
+        destination: /fr/events/create-now/events-sitemap.xml
+        hreflang: fr
+        alternate: /{path}
+      es:
+        source: /es/events/default/metadata.json?sheet=sitemap
+        destination: /es/events/create-now/events-sitemap.xml
+        hreflang: es
+        alternate: /{path}
+      th_en:
+        source: /th_en/events/default/metadata.json?sheet=sitemap
+        destination: /th_en/events/create-now/events-sitemap.xml
+        hreflang: th
         alternate: /{path}


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://sitemap-update-for-extra-locale--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
