### PR TITLE
Add .page as isPreviewMode condition

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -531,8 +531,8 @@ function injectFragments(parent) {
 
 export async function getNonProdData(env) {
   const isPreviewMode = new URLSearchParams(window.location.search).get('previewMode')
-  || window.location.hostname.includes('.hlx.')
-  || window.location.hostname.includes('.aem.');
+  || window.location.hostname.includes('.hlx.page')
+  || window.location.hostname.includes('.aem.page');
 
   const localeMatch = window.location.pathname.match(/^(\/[^/]+)?\/events\//);
   const localePath = localeMatch?.[1] || '';


### PR DESCRIPTION
Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
