### PR TITLE
Chronobox meta deep query

### DIFF
--- a/events/blocks/chrono-box/chrono-box.js
+++ b/events/blocks/chrono-box/chrono-box.js
@@ -1,4 +1,4 @@
-import { readBlockConfig, LIBS, getMetadata } from '../../scripts/utils.js';
+import { readBlockConfig, LIBS, getMetadata, parseMetadataPath } from '../../scripts/utils.js';
 
 function buildScheduleDoubleLinkedList(entries) {
   if (!entries.length) return null;
@@ -38,15 +38,12 @@ function conditionsPreCheck(schedule) {
   allMetadataConditionSchedules.forEach((s) => {
     s.conditions.forEach((condition) => {
       const { key } = condition;
-
-      const metadata = getMetadata(key);
-
+      const metadata = parseMetadataPath(key);
       if (metadata) {
         conditions[key] = metadata;
       }
     });
   });
-
   return conditions;
 }
 

--- a/events/features/timing-framework/worker.js
+++ b/events/features/timing-framework/worker.js
@@ -84,7 +84,10 @@ function isNextScheduleTriggered(scheduleItem) {
 
   const conditionsMet = !c || c.every(({ key: k, expectedValue: v }) => {
     const conditionValue = conditionStore?.[k];
-    const isAnyVal = v.trim().toLowerCase() === 'any' && !!conditionValue;
+    const isEmpty = !conditionValue
+      || (Array.isArray(conditionValue) && conditionValue.length === 0)
+      || (typeof conditionValue === 'object' && Object.keys(conditionValue).length === 0);
+    const isAnyVal = v.trim().toLowerCase() === 'any' && !isEmpty;
     return isAnyVal || conditionValue === v;
   });
 


### PR DESCRIPTION
This is to fix the issue that condition based Timing framework detection can only check metadata's existence. The backend has a constraint where a removed video link from EMC will leave a video metadata tag on the page with an empty video url object: {"url": ""}. To fix that, the TF needs to learn to deep query metadata tags and understand empty objects and arrays as falsy.

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://chronobox-meta-deep-query--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
