### PR TITLE
Update helix-sitemap.yaml (#331) T3-25.26

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -5,7 +5,7 @@ sitemaps:
     languages:
       default:
         source: /events/query-index.json
-        destination: /events/create-now/sitemap.xml
+        destination: /events/sitemap.xml
         hreflang: en
         alternate: /{path}
       de:
@@ -34,7 +34,7 @@ sitemaps:
     languages:
       default:
         source: /events/default/metadata.json?sheet=sitemap
-        destination: /events/create-now/events-sitemap.xml
+        destination: /events/events-sitemap.xml
         hreflang: en
         alternate: /{path}
       de:


### PR DESCRIPTION
Update sitemap to align with event hub page release

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://stage--events-milo--adobecom.aem.live/drafts/
- After: https://dev--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
