### PR TITLE
Add noHtml Exception

### DIFF
--- a/events/scripts/scripts.js
+++ b/events/scripts/scripts.js
@@ -81,6 +81,11 @@ const CONFIG = {
   contentRoot: '/events',
   imsClientId: 'events-milo',
   miloLibs: LIBS,
+  htmlExclude: [
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?learn(\/.*)?/,
+  ],
   // imsScope: 'AdobeID,openid,gnav',
   // geoRouting: 'off',
   // fallbackRouting: 'off',


### PR DESCRIPTION
Test URLs:
- Before: https://stage--events-milo--adobecom.aem.live/drafts/
- After: https://dev--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
