### PR TITLE
Expand and move the sitemap-index.xml after events hub release

### DIFF
--- a/events/create-now/sitemap-index.xml
+++ b/events/create-now/sitemap-index.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <sitemap>
-    <loc>https://www.adobe.com/events/create-now/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/events/create-now/events-sitemap.xml</loc>
-  </sitemap>
-</sitemapindex>

--- a/events/sitemap-index.xml
+++ b/events/sitemap-index.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.adobe.com/events/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/events/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/th_en/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/th_en/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
We missed updating sitemap-index.xml in the recent events hub page release. This PR is to update the sitemap-index.xml file so that our new sitemap can be loaded to adobe.com/events/sitemap-index.xml and replace the Dexter AEM version on EN locale.

Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
