### PR TITLE
Fix missing alt-text in speaker photos

### DIFF
--- a/events/blocks/profile-cards/profile-cards.js
+++ b/events/blocks/profile-cards/profile-cards.js
@@ -6,11 +6,15 @@ const { createTag, getConfig } = await import(`${LIBS}/utils/utils.js`);
 function decorateImage(card, photo) {
   if (!photo) return;
 
-  const { sharepointUrl, imageUrl } = photo;
+  const { sharepointUrl, imageUrl, altText } = photo;
   const imgElement = createTag('img', {
     src: sharepointUrl || imageUrl,
     class: 'card-image',
   });
+
+  if (altText) {
+    imgElement.setAttribute('alt', altText);
+  }
 
   const imgContainer = createTag('div', { class: 'card-image-container' });
   imgContainer.append(imgElement);


### PR DESCRIPTION
The FE didn't properly surface the altText generated by the BE for the speakers. This should fix it.

![Screenshot 2025-06-25 at 11 46 29 AM](https://github.com/user-attachments/assets/808cf187-cdc4-4a96-a225-08545fbbc68d)
![Screenshot 2025-06-25 at 11 46 08 AM](https://github.com/user-attachments/assets/daa8e21d-f81e-461f-98c2-88f9846c4579)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://profile-card-image-alt-text--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
