### PR TITLE
Sitemap hotfix

### DIFF
--- a/events/create-now/sitemap-index.xml
+++ b/events/create-now/sitemap-index.xml
@@ -30,4 +30,10 @@
   <sitemap>
     <loc>https://www.adobe.com/th_en/events/create-now/events-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/uk/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/uk/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/events/create-now/sitemap-index.xml
+++ b/events/create-now/sitemap-index.xml
@@ -6,4 +6,28 @@
   <sitemap>
     <loc>https://www.adobe.com/events/create-now/events-sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/de/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/fr/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/es/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/th_en/events/create-now/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.adobe.com/th_en/events/create-now/events-sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,4 +1,4 @@
-version: 1.1
+version: 1.2
 
 indices:
   website: &website

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -29,6 +29,11 @@ sitemaps:
         destination: /th_en/events/create-now/sitemap.xml
         hreflang: th_EN
         alternate: /{path}
+      uk:
+        source: /uk/events/query-index.json
+        destination: /uk/events/create-now/sitemap.xml
+        hreflang: en_GB
+        alternate: /{path}
   
   seo-templates:
     origin: https://www.adobe.com
@@ -57,4 +62,9 @@ sitemaps:
         source: /th_en/events/default/metadata.json?sheet=sitemap
         destination: /th_en/events/create-now/events-sitemap.xml
         hreflang: th_EN
+        alternate: /{path}
+      uk:
+        source: /uk/events/default/metadata.json?sheet=sitemap
+        destination: /uk/events/create-now/events-sitemap.xml
+        hreflang: en_GB
         alternate: /{path}

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,32 +1,33 @@
-version: 1.1
+version: 1.2
 sitemaps:
   website:
     origin: https://www.adobe.com
+
     languages:
       default:
         source: /events/query-index.json
-        destination: /events/sitemap.xml
-        hreflang: en
+        destination: /events/create-now/sitemap.xml
+        hreflang: en_US
         alternate: /{path}
       de:
         source: /de/events/query-index.json
         destination: /de/events/create-now/sitemap.xml
-        hreflang: de
+        hreflang: de_DE
         alternate: /{path}
       fr:
         source: /fr/events/query-index.json
         destination: /fr/events/create-now/sitemap.xml
-        hreflang: fr
+        hreflang: fr_FR
         alternate: /{path}
       es:
         source: /es/events/query-index.json
         destination: /es/events/create-now/sitemap.xml
-        hreflang: es
+        hreflang: es_ES
         alternate: /{path}
       th_en:
         source: /th_en/events/query-index.json
         destination: /th_en/events/create-now/sitemap.xml
-        hreflang: th
+        hreflang: th_EN
         alternate: /{path}
   
   seo-templates:
@@ -34,26 +35,26 @@ sitemaps:
     languages:
       default:
         source: /events/default/metadata.json?sheet=sitemap
-        destination: /events/events-sitemap.xml
-        hreflang: en
+        destination: /events/create-now/events-sitemap.xml
+        hreflang: en_US
         alternate: /{path}
       de:
         source: /de/events/default/metadata.json?sheet=sitemap
         destination: /de/events/create-now/events-sitemap.xml
-        hreflang: de
+        hreflang: de_DE
         alternate: /{path}
       fr:
         source: /fr/events/default/metadata.json?sheet=sitemap
         destination: /fr/events/create-now/events-sitemap.xml
-        hreflang: fr
+        hreflang: fr_FR
         alternate: /{path}
       es:
         source: /es/events/default/metadata.json?sheet=sitemap
         destination: /es/events/create-now/events-sitemap.xml
-        hreflang: es
+        hreflang: es_ES
         alternate: /{path}
       th_en:
         source: /th_en/events/default/metadata.json?sheet=sitemap
         destination: /th_en/events/create-now/events-sitemap.xml
-        hreflang: th
+        hreflang: th_EN
         alternate: /{path}


### PR DESCRIPTION
Added UK
Added country-based sitemap hreflang
Revert to create-now sitemap location

Test URLs:
- Before: https://main--events-milo--adobecom.aem.live/drafts/
- After: https://sitemap-hotfix--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
