### PR TITLE
Sitemap Fix#2

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -46,24 +46,24 @@ sitemaps:
         source: /de/events/default/metadata.json?sheet=sitemap
         destination: /de/events/create-now/events-sitemap.xml
         hreflang: de
-        alternate: /{path}
+        alternate: /de/{path}
       fr:
         source: /fr/events/default/metadata.json?sheet=sitemap
         destination: /fr/events/create-now/events-sitemap.xml
         hreflang: fr
-        alternate: /{path}
+        alternate: /fr/{path}
       es:
         source: /es/events/default/metadata.json?sheet=sitemap
         destination: /es/events/create-now/events-sitemap.xml
         hreflang: es
-        alternate: /{path}
+        alternate: /es/{path}
       th_en:
         source: /th_en/events/default/metadata.json?sheet=sitemap
         destination: /th_en/events/create-now/events-sitemap.xml
         hreflang: th-EN
-        alternate: /{path}
+        alternate: /th_en/{path}
       uk:
         source: /uk/events/default/metadata.json?sheet=sitemap
         destination: /uk/events/create-now/events-sitemap.xml
         hreflang: en-GB
-        alternate: /{path}
+        alternate: /uk/{path}


### PR DESCRIPTION
Fixing syntax issue in our current sitemap.yaml file since incorporating the SEO recommended changes.

Test URLs:
- Before: https://main--events-milo--adobecom.aem.live/drafts/
- After: https://sitemap-fix-2--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
