### PR TITLE
ROW events migration - configure prodDomains

### DIFF
--- a/events/scripts/scripts.js
+++ b/events/scripts/scripts.js
@@ -72,6 +72,8 @@ export default function decorateArea(area = document) {
   autoUpdateContent(area, miloDeps, photosData);
 }
 
+const prodDomains = ['milo.adobe.com', 'business.adobe.com', 'www.adobe.com', 'news.adobe.com'];
+
 // Add project-wide style path here.
 const STYLES = '';
 
@@ -81,6 +83,7 @@ const CONFIG = {
   contentRoot: '/events',
   imsClientId: 'events-milo',
   miloLibs: LIBS,
+  prodDomains,
   htmlExclude: [
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,


### PR DESCRIPTION
Adding prodDomain constance according to Milo team's instruction to enabled #_dnt handle support.

Resolves: [MWPW-175962](https://jira.corp.adobe.com/browse/MWPW-175962)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://prod-domain--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
