### PR TITLE
Fixing the RSVP state in a simpler way

### DIFF
--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -148,7 +148,6 @@ function createTag(tag, attributes, html, options = {}) {
 }
 
 export async function updateRSVPButtonState(rsvpBtn, miloLibs) {
-  const rsvpData = BlockMediator.get('rsvpData');
   const eventInfo = await getEvent(getMetadata('event-id'));
   let eventFull = false;
   let waitlistEnabled = getMetadata('allow-wait-listing') === 'true';
@@ -160,6 +159,7 @@ export async function updateRSVPButtonState(rsvpBtn, miloLibs) {
     waitlistEnabled = allowWaitlisting;
   }
 
+  const rsvpData = BlockMediator.get('rsvpData');
   if (!rsvpData) {
     if (eventFull) {
       if (waitlistEnabled) {


### PR DESCRIPTION
Making sure the captured RSVP state value is more up-to-date after the event data call.

Resolves: [MWPW-175192](https://jira.corp.adobe.com/browse/MWPW-175192)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://smaller-rsvp-race-fix--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
