### PR TITLE
[MWPW-176612] : [T1 migration] Add table styling for column text blocks

### DIFF
--- a/events/styles/styles.css
+++ b/events/styles/styles.css
@@ -106,3 +106,29 @@ fieldset {
 body.validating-page {
   display: none;
 }
+
+.text-block[class*="column-text"] table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.text-block[class*="column-text"] table td:last-child {
+  text-align: right;
+}
+
+.text-block.column-text-spacing-xs table {
+  margin: var(--spacing-xs) 0;
+}
+
+.text-block.column-text-spacing-s table {
+  margin: var(--spacing-s) 0;
+}
+
+.text-block.column-icon-spacing-xs table td:last-child a:not(:last-child) {
+  padding-right: var(--spacing-xs);
+}
+
+.text-block.column-icon-spacing-xxs table td:last-child a:not(:last-child) {
+  padding-right: var(--spacing-xxs);
+}


### PR DESCRIPTION
Added a way to have text and icon side by side in the Milo Text block

Resolves: [MWPW-176612](https://jira.corp.adobe.com/browse/MWPW-176612)

Sample authoring: https://adobe.sharepoint.com/:w:/r/sites/acomevents/_layouts/15/doc2.aspx?sourcedoc=%7B489A3CE1-767C-4072-806C-79856B2A1BA0%7D&file=editorial-card-mpc.docx&action=default&mobileredirect=true

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.page/drafts/sharmeeb/fragments/editorial-card-mpc?martech=off
- After: https://mwpw-176612--events-milo--adobecom.aem.page/drafts/sharmeeb/fragments/editorial-card-mpc?martech=off

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
