### PR TITLE
[MWPW-174658]:- Embed YouTube Chat Alongside Player Block in MILO

### DIFF
--- a/events/blocks/youtube-chat/youtube-chat.css
+++ b/events/blocks/youtube-chat/youtube-chat.css
@@ -1,0 +1,54 @@
+.youtube-chat .youtube-stream {
+  display: flex;
+  max-width: 100%;
+  margin: 0 auto;
+  flex-wrap: wrap;
+}
+
+.youtube-chat .youtube-video-container {
+  width: 100%;
+  max-width: 100%;
+  flex: 1 1 auto;
+  min-height: auto;  
+}
+
+.youtube-chat .youtube-video-container .iframe-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+}
+
+.youtube-chat .youtube-chat-container {
+  width: 100%;
+  max-width: 100%;
+  flex: 1 1 auto;
+  min-height: 500px;
+}
+
+.youtube-chat .youtube-chat-container .iframe-container {
+  height: 100%;
+  padding-bottom: 0;
+  position: relative;
+  width: 100%;
+}
+
+.youtube-chat .youtube-chat-container iframe,
+.youtube-chat .youtube-video-container iframe {
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
+  position: absolute;
+}
+
+@media screen and (min-width: 1200px) {
+  .youtube-chat .youtube-stream:not(.single-column) .youtube-video-container {
+      width: 75%;
+      max-width: 75%;
+  }
+
+  .youtube-chat .youtube-chat-container {
+      flex: 1 1 1%;
+      min-height: auto;
+  }
+}

--- a/events/blocks/youtube-chat/youtube-chat.css
+++ b/events/blocks/youtube-chat/youtube-chat.css
@@ -3,19 +3,85 @@
   max-width: 100%;
   margin: 0 auto;
   flex-wrap: wrap;
+  transition: all 0.3s ease-in-out;
 }
 
 .youtube-chat .youtube-video-container {
   width: 100%;
   max-width: 100%;
   flex: 1 1 auto;
-  min-height: auto;  
+  min-height: auto;
+  height: 0;
+  padding-bottom: 56.25%;
+  position: relative;
+  transition: width 0.3s ease-in-out, max-width 0.3s ease-in-out;
 }
 
 .youtube-chat .youtube-video-container .iframe-container {
-  position: relative;
-  padding-bottom: 56.25%;
-  height: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+lite-youtube {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  cursor: pointer;
+  background-color: #000;
+  background-size: cover;
+  background-position: center;
+}
+
+lite-youtube > .lty-playbtn {
+  display: block;
+  width: 68px;
+  height: 48px;
+  position: absolute;
+  cursor: pointer;
+  transform: translate3d(-50%, -50%, 0);
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  background-color: transparent;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+  filter: grayscale(100%);
+  transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
+  border: none;
+}
+
+lite-youtube:hover > .lty-playbtn,
+lite-youtube .lty-playbtn:focus {
+  filter: none;
+}
+
+/* Screen reader only text */
+.lyt-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.youtube-chat .youtube-chat-placeholder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #666;
+  text-align: center;
+  font-size: 14px;
+  background: #f5f5f5;
+  padding: 20px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
 }
 
 .youtube-chat .youtube-chat-container {
@@ -23,6 +89,7 @@
   max-width: 100%;
   flex: 1 1 auto;
   min-height: 500px;
+  transition: all 0.3s ease-in-out;
 }
 
 .youtube-chat .youtube-chat-container .iframe-container {
@@ -42,13 +109,40 @@
 }
 
 @media screen and (min-width: 1200px) {
-  .youtube-chat .youtube-stream:not(.single-column) .youtube-video-container {
-      width: 75%;
-      max-width: 75%;
+  .youtube-chat .youtube-stream:not(.has-chat) .youtube-video-container {
+    width: 100%;
+    max-width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
   }
 
-  .youtube-chat .youtube-chat-container {
-      flex: 1 1 1%;
-      min-height: auto;
+  .youtube-chat .youtube-stream.has-chat .youtube-video-container {
+    width: 100%;
+    max-width: 100%;
+    height: 0;
+    padding-bottom: 42.1875%;
+  }
+
+  .youtube-chat .youtube-stream.has-chat:not(.single-column) .youtube-video-container {
+    width: 75%;
+    max-width: 75%;
+    height: 0;
+    padding-bottom: 42.1875%;
+  }
+
+  .youtube-chat .youtube-stream.has-chat:not(.single-column) .youtube-chat-container {
+    flex: 1 1 1%;
+    min-height: 0;
+    height: auto;
+    padding-bottom: 42.1875%;
+    position: relative;
+  }
+
+  .youtube-chat .youtube-stream.has-chat:not(.single-column) .youtube-chat-container .iframe-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 }

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -83,9 +83,7 @@ export class YouTubeChat {
 }
 
 // Maintain backward compatibility with existing API
-async function init(block) {
+export default async function init(block) {
   const youtubeChat = new YouTubeChat();
   await youtubeChat.init(block);
 }
-
-export default init;

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -1,82 +1,203 @@
 import { createTag, readBlockConfig } from '../../scripts/utils.js';
 
+const CONFIG = {
+  PRELOAD_DOMAINS: [
+    'www.youtube-nocookie.com',
+    'www.youtube.com',
+    'www.google.com',
+    'googleads.g.doubleclick.net',
+    'static.doubleclick.net',
+  ],
+  YOUTUBE_EMBED_BASE: 'https://www.youtube-nocookie.com/embed',
+  YOUTUBE_CHAT_BASE: 'https://www.youtube.com/live_chat',
+  THUMBNAIL_BASE: 'https://i.ytimg.com/vi',
+  PLAYER_OPTIONS: {
+    autoplay: 'autoplay',
+    mute: 'mute',
+    'show-controls': 'controls',
+    'show-player-title-actions': 'modestbranding',
+    'show-suggestions-after-video-ends': 'rel',
+  },
+  IFRAME_ATTRIBUTES: {
+    allowfullscreen: true,
+    allow: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+  },
+  DEFAULT_TITLE: 'YouTube video player',
+  CHAT_LOAD_DELAY: 100,
+};
+
 export class YouTubeChat {
   constructor() {
     this.config = null;
     this.videoId = null;
     this.chatEnabled = false;
+    this.videoLoaded = false;
+    this.pendingChatSection = null;
+    this.chatContainer = null;
   }
 
   async init(block) {
-    this.config = readBlockConfig(block);
-    this.videoId = this.config['videoid'];
-    this.chatEnabled = this.config['chatenabled']?.toLowerCase() === 'true';
+    try {
+      this.config = readBlockConfig(block);
+      this.videoId = this.config.videoid;
+      this.chatEnabled = this.config.chatenabled?.toLowerCase() === 'true';
 
-    if (!this.videoId) {
-      window.lana?.log('YouTube Chat Block: Invalid or missing video ID.');
+      if (!this.videoId) throw new Error('Invalid or missing video ID.');
+
+      this.preconnect();
+      block.textContent = '';
+      block.append(this.buildStream());
+    } catch (err) {
+      window.lana?.log(`YouTube Chat Block: ${err.message}`);
       block.remove();
-      return;
     }
-
-    block.textContent = '';
-    block.append(this.buildYouTubeStream());
   }
 
-  buildYouTubeStream() {
+  preconnect() {
+    if (YouTubeChat.preconnected) return;
+    YouTubeChat.preconnected = true;
+
+    CONFIG.PRELOAD_DOMAINS.forEach(domain => {
+      const link = createTag('link', { rel: 'preconnect', href: `https://${domain}` });
+      document.head.appendChild(link);
+    });
+  }
+
+  buildStream() {
+    const autoplay = this.isAutoplayEnabled();
     const container = createTag('div', {
-      class: `youtube-stream${!this.chatEnabled ? ' single-column' : ''}`,
+      class: `youtube-stream${!this.chatEnabled || !autoplay ? ' single-column' : ''}${this.chatEnabled ? ' has-chat' : ''}`.trim(),
     });
 
-    container.append(this.createVideoSection());
-    if (this.chatEnabled) {
-      container.append(this.createChatSection());
-    }
+    container.append(this.buildVideoSection(autoplay));
+    if (this.chatEnabled && autoplay) container.append(this.buildChatSection());
+    if (this.chatEnabled && !autoplay) this.pendingChatSection = this.buildChatSection();
 
     return container;
   }
 
-  createVideoSection() {
-    const iframe = createTag('iframe', {
-      class: 'youtube-video',
-      src: this.buildEmbedUrl(),
-      allowfullscreen: true,
-      title: this.config.videotitle || 'YouTube video player',
-    });
+  buildVideoSection(autoplay) {
+    const container = createTag('div', { class: 'youtube-video-container' });
+    const wrapper = createTag('div', { class: 'iframe-container' });
 
-    const wrapper = createTag('div', { class: 'iframe-container' }, iframe);
-    return createTag('div', { class: 'youtube-video-container' }, wrapper);
+    autoplay ? this.insertAutoplayIframe(wrapper) : this.insertLitePlayer(wrapper);
+    container.append(wrapper);
+    return container;
   }
 
-  createChatSection() {
-    const chatIframe = createTag('iframe', {
+  insertAutoplayIframe(wrapper) {
+    const iframe = this.createVideoIframe(this.buildEmbedUrl(true));
+    wrapper.append(iframe);
+    this.videoLoaded = true;
+    if (this.chatEnabled) setTimeout(() => this.loadChat(), CONFIG.CHAT_LOAD_DELAY);
+  }
+
+  insertLitePlayer(wrapper) {
+    const liteYT = createTag('lite-youtube', {
+      videoid: this.videoId,
+      playlabel: this.getVideoTitle(),
+      params: this.buildUrlParams(),
+    });
+
+    liteYT.style.backgroundImage = `url("${CONFIG.THUMBNAIL_BASE}/${this.videoId}/hqdefault.jpg")`;
+    liteYT.style.backgroundSize = 'cover';
+    liteYT.style.backgroundPosition = 'center';
+
+    const playBtn = createTag('button', { type: 'button', class: 'lty-playbtn' });
+    const label = createTag('span', { class: 'lyt-visually-hidden' });
+    label.textContent = this.getVideoTitle();
+    playBtn.append(label);
+    liteYT.append(playBtn);
+
+    liteYT.addEventListener('click', () => this.activateLitePlayer(liteYT));
+    wrapper.append(liteYT);
+  }
+
+  activateLitePlayer(liteYT) {
+    if (this.videoLoaded) return;
+    this.videoLoaded = true;
+    liteYT.classList.add('lyt-activated');
+
+    const container = liteYT.closest('.youtube-stream');
+    if (this.pendingChatSection && container) {
+      container.append(this.pendingChatSection);
+      container.classList.remove('single-column');
+    }
+
+    const iframe = this.createVideoIframe(this.buildEmbedUrl(true));
+    liteYT.insertAdjacentElement('afterend', iframe);
+    liteYT.remove();
+
+    if (this.chatEnabled) this.loadChat();
+  }
+
+  buildChatSection() {
+    this.chatContainer = createTag('div', { class: 'youtube-chat-container' });
+    const wrapper = createTag('div', { class: 'iframe-container' });
+    const msg = this.isAutoplayEnabled() ? 'Loading chat...' : 'Chat will load when video is played';
+    const placeholder = createTag('div', { class: 'youtube-chat-placeholder' }, msg);
+    wrapper.append(placeholder);
+    this.chatContainer.append(wrapper);
+    return this.chatContainer;
+  }
+
+  loadChat() {
+    if (!this.chatContainer) return;
+    const iframe = createTag('iframe', {
       class: 'youtube-chat',
-      src: `https://www.youtube.com/live_chat?v=${this.videoId}&embed_domain=${window.location.hostname}`,
+      src: `${CONFIG.YOUTUBE_CHAT_BASE}?v=${this.videoId}&embed_domain=${window.location.hostname}`,
       title: 'YouTube live chat',
     });
 
-    const wrapper = createTag('div', { class: 'iframe-container' }, chatIframe);
-    return createTag('div', { class: 'youtube-chat-container' }, wrapper);
+    const wrapper = createTag('div', { class: 'iframe-container' }, iframe);
+    this.chatContainer.innerHTML = '';
+    this.chatContainer.append(wrapper);
   }
 
-  buildEmbedUrl() {
-    const base = `https://www.youtube.com/embed/${this.videoId}`;
+  createVideoIframe(src) {
+    return createTag('iframe', {
+      class: 'youtube-video',
+      src,
+      title: this.getVideoTitle(),
+      loading: 'lazy',
+      ...CONFIG.IFRAME_ATTRIBUTES,
+    });
+  }
+
+  getVideoTitle() {
+    return this.config.videotitle || CONFIG.DEFAULT_TITLE;
+  }
+
+  isAutoplayEnabled() {
+    return this.config.autoplay?.toLowerCase() === 'true';
+  }
+
+  buildEmbedUrl(autoplay = false) {
+    const base = `${CONFIG.YOUTUBE_EMBED_BASE}/${this.videoId}`;
     const params = new URLSearchParams();
 
-    const options = {
-      autoplay: 'autoplay',
-      mute: 'mute',
-      'show-controls': 'controls',
-      'show-player-title-actions': 'modestbranding',
-      'show-suggestions-after-video-ends': 'rel',
-    };
+    if (autoplay) {
+      params.append('autoplay', '1');
+      params.append('mute', '1');
+    }
 
-    for (const [key, param] of Object.entries(options)) {
+    Object.entries(CONFIG.PLAYER_OPTIONS).forEach(([key, param]) => {
       if (this.config[key]?.toLowerCase?.() === 'true') {
         params.append(param, '1');
       }
-    }
+    });
 
-    return params.toString() ? `${base}?${params}` : base;
+    return `${base}?${params}`;
+  }
+
+  buildUrlParams() {
+    const params = new URLSearchParams();
+    Object.entries(CONFIG.PLAYER_OPTIONS).forEach(([key, param]) => {
+      if (this.config[key]?.toLowerCase?.() === 'true') {
+        params.append(param, '1');
+      }
+    });
+    return params.toString();
   }
 }
 

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -1,0 +1,73 @@
+import { createTag, readBlockConfig } from '../../scripts/utils.js';
+
+export default async function init(block) {
+  const config = readBlockConfig(block);
+  const videoId = config['videoid'];
+  const chatEnabled = config['chatenabled']?.toLowerCase() === 'true';
+
+  if (!videoId) {
+    window.lana?.log('YouTube Chat Block: Invalid or missing video ID.');
+    block.remove();
+    return;
+  }
+
+  block.textContent = '';
+  block.append(buildYouTubeStream(videoId, config, chatEnabled));
+}
+
+function buildYouTubeStream(videoId, config, showChat) {
+  const container = createTag('div', {
+    class: `youtube-stream${!showChat ? ' single-column' : ''}`,
+  });
+
+  container.append(createVideoSection(videoId, config));
+  if (showChat) container.append(createChatSection(videoId));
+
+  return container;
+}
+
+function createVideoSection(videoId, config) {
+  const iframe = createTag('iframe', {
+    class: 'youtube-video',
+    src: buildEmbedUrl(videoId, config),
+    allowfullscreen: true,
+    title: config.videotitle || 'YouTube video player',
+    loading: 'lazy',
+  });
+
+  const wrapper = createTag('div', { class: 'iframe-container' }, iframe);
+  return createTag('div', { class: 'youtube-video-container' }, wrapper);
+}
+
+function createChatSection(videoId) {
+  const chatIframe = createTag('iframe', {
+    class: 'youtube-chat',
+    src: `https://www.youtube.com/live_chat?v=${videoId}&embed_domain=${window.location.hostname}`,
+    title: `YouTube live chat`,
+    loading: 'lazy',
+  });
+
+  const wrapper = createTag('div', { class: 'iframe-container' }, chatIframe);
+  return createTag('div', { class: 'youtube-chat-container' }, wrapper);
+}
+
+function buildEmbedUrl(videoId, config) {
+  const base = `https://www.youtube.com/embed/${videoId}`;
+  const params = new URLSearchParams();
+
+  const options = {
+    autoplay: 'autoplay',
+    mute: 'mute',
+    'show-controls': 'controls',
+    'show-player-title-actions': 'modestbranding',
+    'show-suggestions-after-video-ends': 'rel',
+  };
+
+  for (const [key, param] of Object.entries(options)) {
+    if (config[key]?.toLowerCase?.() === 'true') {
+      params.append(param, '1');
+    }
+  }
+
+  return params.toString() ? `${base}?${params}` : base;
+}

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -1,6 +1,6 @@
 import { createTag, readBlockConfig } from '../../scripts/utils.js';
 
-export default class YouTubeChat {
+export class YouTubeChat {
   constructor() {
     this.config = null;
     this.videoId = null;
@@ -83,7 +83,9 @@ export default class YouTubeChat {
 }
 
 // Maintain backward compatibility with existing API
-export async function init(block) {
+async function init(block) {
   const youtubeChat = new YouTubeChat();
   await youtubeChat.init(block);
 }
+
+export default init;

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -41,7 +41,6 @@ export class YouTubeChat {
       src: this.buildEmbedUrl(),
       allowfullscreen: true,
       title: this.config.videotitle || 'YouTube video player',
-      loading: 'lazy',
     });
 
     const wrapper = createTag('div', { class: 'iframe-container' }, iframe);
@@ -53,7 +52,6 @@ export class YouTubeChat {
       class: 'youtube-chat',
       src: `https://www.youtube.com/live_chat?v=${this.videoId}&embed_domain=${window.location.hostname}`,
       title: 'YouTube live chat',
-      loading: 'lazy',
     });
 
     const wrapper = createTag('div', { class: 'iframe-container' }, chatIframe);

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -80,7 +80,6 @@ export class YouTubeChat {
   }
 }
 
-// Maintain backward compatibility with existing API
 export default async function init(block) {
   const youtubeChat = new YouTubeChat();
   await youtubeChat.init(block);

--- a/test/unit/blocks/youtube-chat/mocks/default.html
+++ b/test/unit/blocks/youtube-chat/mocks/default.html
@@ -1,0 +1,34 @@
+<div class="youtube-chat">
+  <div>
+    <div>videoid</div>
+    <div>dQw4w9WgXcQ</div>
+  </div>
+  <div>
+    <div>title</div>
+    <div>My Custom Video Title</div>
+  </div>
+  <div>
+    <div>chatenabled</div>
+    <div>true</div>
+  </div>
+  <div>
+    <div>autoplay</div>
+    <div>true</div>
+  </div>
+  <div>
+    <div>mute</div>
+    <div>true</div>
+  </div>
+  <div>
+    <div>show-controls</div>
+    <div>true</div>
+  </div>
+  <div>
+    <div>show-player-title-actions</div>
+    <div>true</div>
+  </div>
+  <div>
+    <div>show-suggestions-after-video-ends</div>
+    <div>false</div>
+  </div>
+</div>

--- a/test/unit/blocks/youtube-chat/youtube-chat.test.js
+++ b/test/unit/blocks/youtube-chat/youtube-chat.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { readFile } from '@web/test-runner-commands';
-import YouTubeChat, { init } from '../../../../events/blocks/youtube-chat/youtube-chat.js';
+import init, { YouTubeChat } from '../../../../events/blocks/youtube-chat/youtube-chat.js';
 
 const defaultHtml = await readFile({ path: './mocks/default.html' });
 

--- a/test/unit/blocks/youtube-chat/youtube-chat.test.js
+++ b/test/unit/blocks/youtube-chat/youtube-chat.test.js
@@ -10,8 +10,6 @@ describe('YouTube Chat Module', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    
-    // Reset DOM
     document.body.innerHTML = '';
   });
 
@@ -37,6 +35,9 @@ describe('YouTube Chat Module', () => {
     describe('buildEmbedUrl', () => {
       beforeEach(() => {
         youtubeChat.videoId = 'dQw4w9WgXcQ';
+      });
+
+      it('should build URL with all parameters when enabled', () => {
         youtubeChat.config = {
           autoplay: 'true',
           mute: 'true',
@@ -44,9 +45,7 @@ describe('YouTube Chat Module', () => {
           'show-player-title-actions': 'true',
           'show-suggestions-after-video-ends': 'false'
         };
-      });
 
-      it('should build URL with all parameters when enabled', () => {
         const url = youtubeChat.buildEmbedUrl();
         expect(url).to.include('https://www.youtube.com/embed/dQw4w9WgXcQ');
         expect(url).to.include('autoplay=1');
@@ -95,7 +94,7 @@ describe('YouTube Chat Module', () => {
         };
       });
 
-      it('should create video section with correct structure', () => {
+      it('should create video section with correct structure and attributes', () => {
         const videoSection = youtubeChat.createVideoSection();
         
         expect(videoSection.classList.contains('youtube-video-container')).to.be.true;
@@ -126,7 +125,7 @@ describe('YouTube Chat Module', () => {
         youtubeChat.videoId = 'dQw4w9WgXcQ';
       });
 
-      it('should create chat section with correct structure', () => {
+      it('should create chat section with correct structure and attributes', () => {
         const chatSection = youtubeChat.createChatSection();
         
         expect(chatSection.classList.contains('youtube-chat-container')).to.be.true;
@@ -182,7 +181,7 @@ describe('YouTube Chat Module', () => {
     });
   });
 
-  describe('init function (backward compatibility)', () => {
+  describe('Integration Tests', () => {
     it('should initialize YouTube chat with video and chat enabled', async () => {
       document.body.innerHTML = defaultHtml;
       const block = document.querySelector('.youtube-chat');
@@ -214,7 +213,6 @@ describe('YouTube Chat Module', () => {
     });
 
     it('should initialize YouTube stream without chat when chatenabled is false', async () => {
-      // Create HTML with chatenabled set to false
       const htmlWithoutChat = `
         <div class="youtube-chat">
           <div>
@@ -241,17 +239,10 @@ describe('YouTube Chat Module', () => {
       
       await init(block);
       
-      // Verify that the block content was cleared
-      expect(block.textContent).to.equal('');
-      
-      // Verify that a container was created
       const container = block.querySelector('.youtube-stream');
       expect(container).to.not.be.null;
-      
-      // Verify that single-column class was added
       expect(container.classList.contains('single-column')).to.be.true;
       
-      // Verify that only video container was created
       const videoContainer = container.querySelector('.youtube-video-container');
       expect(videoContainer).to.not.be.null;
       
@@ -260,7 +251,6 @@ describe('YouTube Chat Module', () => {
     });
 
     it('should not initialize when videoId is missing', async () => {
-      // Create HTML without videoId
       const htmlWithoutVideoId = `
         <div class="youtube-chat">
           <div>
@@ -282,43 +272,9 @@ describe('YouTube Chat Module', () => {
       // Verify that the block was removed from DOM
       expect(document.querySelector('.youtube-chat')).to.be.null;
     });
-  });
 
-  describe('DOM structure', () => {
-    it('should create proper nested DOM structure', async () => {
-      document.body.innerHTML = defaultHtml;
-      const block = document.querySelector('.youtube-chat');
-      
-      await init(block);
-      
-      // Verify the complete DOM structure
-      const container = block.querySelector('.youtube-stream');
-      expect(container).to.not.be.null;
-      
-      // Video structure
-      const videoWrapper = container.querySelector('.youtube-video-container');
-      expect(videoWrapper).to.not.be.null;
-      
-      const videoContainer = videoWrapper.querySelector('.iframe-container');
-      expect(videoContainer).to.not.be.null;
-      
-      const videoIframe = videoContainer.querySelector('.youtube-video');
-      expect(videoIframe).to.not.be.null;
-      
-      // Chat structure
-      const chatWrap = container.querySelector('.youtube-chat-container');
-      expect(chatWrap).to.not.be.null;
-      
-      const chatContainer = chatWrap.querySelector('.iframe-container');
-      expect(chatContainer).to.not.be.null;
-      
-      const chatIframe = chatContainer.querySelector('.youtube-chat');
-      expect(chatIframe).to.not.be.null;
-    });
-
-    it('should create single-column structure when chat is disabled', async () => {
-      // Create HTML with chatenabled set to false
-      const htmlWithoutChat = `
+    it('should handle different configuration options', async () => {
+      const htmlWithMixedConfig = `
         <div class="youtube-chat">
           <div>
             <div>videoid</div>
@@ -326,40 +282,28 @@ describe('YouTube Chat Module', () => {
           </div>
           <div>
             <div>chatenabled</div>
-            <div>false</div>
+            <div>true</div>
           </div>
           <div>
             <div>autoplay</div>
-            <div>true</div>
+            <div>false</div>
           </div>
           <div>
             <div>mute</div>
             <div>true</div>
           </div>
+          <div>
+            <div>show-controls</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>show-player-title-actions</div>
+            <div>false</div>
+          </div>
         </div>
       `;
       
-      document.body.innerHTML = htmlWithoutChat;
-      const block = document.querySelector('.youtube-chat');
-      
-      await init(block);
-      
-      const container = block.querySelector('.youtube-stream');
-      expect(container).to.not.be.null;
-      expect(container.classList.contains('single-column')).to.be.true;
-      
-      // Should only have video structure
-      const videoWrapper = container.querySelector('.youtube-video-container');
-      expect(videoWrapper).to.not.be.null;
-      
-      const chatWrap = container.querySelector('.youtube-chat-container');
-      expect(chatWrap).to.be.null;
-    });
-  });
-
-  describe('URL generation', () => {
-    it('should build video URL with parameters', async () => {
-      document.body.innerHTML = defaultHtml;
+      document.body.innerHTML = htmlWithMixedConfig;
       const block = document.querySelector('.youtube-chat');
       
       await init(block);
@@ -369,98 +313,10 @@ describe('YouTube Chat Module', () => {
       
       const src = videoIframe.getAttribute('src');
       expect(src).to.include('https://www.youtube.com/embed/dQw4w9WgXcQ');
-      expect(src).to.include('autoplay=1');
-      expect(src).to.include('mute=1');
-      expect(src).to.include('controls=1');
-      expect(src).to.include('modestbranding=1');
-    });
-
-    it('should build chat URL with correct parameters', async () => {
-      document.body.innerHTML = defaultHtml;
-      const block = document.querySelector('.youtube-chat');
-      
-      await init(block);
-      
-      const chatIframe = block.querySelector('.youtube-chat');
-      expect(chatIframe).to.not.be.null;
-      
-      const src = chatIframe.getAttribute('src');
-      expect(src).to.include('https://www.youtube.com/live_chat?v=dQw4w9WgXcQ');
-      expect(src).to.include('embed_domain=');
-    });
-  });
-
-  describe('Configuration options', () => {
-    it('should handle different autoplay settings', async () => {
-      // Create HTML with autoplay disabled
-      const htmlWithAutoplayDisabled = `
-        <div class="youtube-chat">
-          <div>
-            <div>videoid</div>
-            <div>dQw4w9WgXcQ</div>
-          </div>
-          <div>
-            <div>chatenabled</div>
-            <div>true</div>
-          </div>
-          <div>
-            <div>autoplay</div>
-            <div>false</div>
-          </div>
-          <div>
-            <div>mute</div>
-            <div>true</div>
-          </div>
-        </div>
-      `;
-      
-      document.body.innerHTML = htmlWithAutoplayDisabled;
-      const block = document.querySelector('.youtube-chat');
-      
-      await init(block);
-      
-      const videoIframe = block.querySelector('.youtube-video');
-      expect(videoIframe).to.not.be.null;
-      
-      const src = videoIframe.getAttribute('src');
       expect(src).to.not.include('autoplay=1');
       expect(src).to.include('mute=1');
-    });
-
-    it('should handle different mute settings', async () => {
-      // Create HTML with mute disabled
-      const htmlWithMuteDisabled = `
-        <div class="youtube-chat">
-          <div>
-            <div>videoid</div>
-            <div>dQw4w9WgXcQ</div>
-          </div>
-          <div>
-            <div>chatenabled</div>
-            <div>true</div>
-          </div>
-          <div>
-            <div>autoplay</div>
-            <div>true</div>
-          </div>
-          <div>
-            <div>mute</div>
-            <div>false</div>
-          </div>
-        </div>
-      `;
-      
-      document.body.innerHTML = htmlWithMuteDisabled;
-      const block = document.querySelector('.youtube-chat');
-      
-      await init(block);
-      
-      const videoIframe = block.querySelector('.youtube-video');
-      expect(videoIframe).to.not.be.null;
-      
-      const src = videoIframe.getAttribute('src');
-      expect(src).to.include('autoplay=1');
-      expect(src).to.not.include('mute=1');
+      expect(src).to.include('controls=1');
+      expect(src).to.not.include('modestbranding=1');
     });
   });
 });

--- a/test/unit/blocks/youtube-chat/youtube-chat.test.js
+++ b/test/unit/blocks/youtube-chat/youtube-chat.test.js
@@ -106,7 +106,6 @@ describe('YouTube Chat Module', () => {
         expect(iframe).to.not.be.null;
         expect(iframe.tagName).to.equal('IFRAME');
         expect(iframe.getAttribute('title')).to.equal('Custom Video Title');
-        expect(iframe.getAttribute('loading')).to.equal('lazy');
         expect(iframe.getAttribute('allowfullscreen')).to.equal('true');
       });
 
@@ -137,7 +136,6 @@ describe('YouTube Chat Module', () => {
         expect(iframe).to.not.be.null;
         expect(iframe.tagName).to.equal('IFRAME');
         expect(iframe.getAttribute('title')).to.equal('YouTube live chat');
-        expect(iframe.getAttribute('loading')).to.equal('lazy');
         expect(iframe.getAttribute('src')).to.include('https://www.youtube.com/live_chat?v=dQw4w9WgXcQ');
         expect(iframe.getAttribute('src')).to.include('embed_domain=');
       });

--- a/test/unit/blocks/youtube-chat/youtube-chat.test.js
+++ b/test/unit/blocks/youtube-chat/youtube-chat.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { readFile } from '@web/test-runner-commands';
-import init from '../../../../events/blocks/youtube-chat/youtube-chat.js';
+import YouTubeChat, { init } from '../../../../events/blocks/youtube-chat/youtube-chat.js';
 
 const defaultHtml = await readFile({ path: './mocks/default.html' });
 
@@ -10,7 +10,7 @@ describe('YouTube Chat Module', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-
+    
     // Reset DOM
     document.body.innerHTML = '';
   });
@@ -19,32 +19,195 @@ describe('YouTube Chat Module', () => {
     sandbox.restore();
   });
 
-  describe('init', () => {
+  describe('YouTubeChat Class', () => {
+    let youtubeChat;
+
+    beforeEach(() => {
+      youtubeChat = new YouTubeChat();
+    });
+
+    describe('constructor', () => {
+      it('should initialize with default values', () => {
+        expect(youtubeChat.config).to.be.null;
+        expect(youtubeChat.videoId).to.be.null;
+        expect(youtubeChat.chatEnabled).to.be.false;
+      });
+    });
+
+    describe('buildEmbedUrl', () => {
+      beforeEach(() => {
+        youtubeChat.videoId = 'dQw4w9WgXcQ';
+        youtubeChat.config = {
+          autoplay: 'true',
+          mute: 'true',
+          'show-controls': 'true',
+          'show-player-title-actions': 'true',
+          'show-suggestions-after-video-ends': 'false'
+        };
+      });
+
+      it('should build URL with all parameters when enabled', () => {
+        const url = youtubeChat.buildEmbedUrl();
+        expect(url).to.include('https://www.youtube.com/embed/dQw4w9WgXcQ');
+        expect(url).to.include('autoplay=1');
+        expect(url).to.include('mute=1');
+        expect(url).to.include('controls=1');
+        expect(url).to.include('modestbranding=1');
+        expect(url).to.not.include('rel=1');
+      });
+
+      it('should build URL without parameters when disabled', () => {
+        youtubeChat.config = {
+          autoplay: 'false',
+          mute: 'false',
+          'show-controls': 'false',
+          'show-player-title-actions': 'false',
+          'show-suggestions-after-video-ends': 'false'
+        };
+        
+        const url = youtubeChat.buildEmbedUrl();
+        expect(url).to.equal('https://www.youtube.com/embed/dQw4w9WgXcQ');
+      });
+
+      it('should handle mixed configuration', () => {
+        youtubeChat.config = {
+          autoplay: 'true',
+          mute: 'false',
+          'show-controls': 'true',
+          'show-player-title-actions': 'false'
+        };
+        
+        const url = youtubeChat.buildEmbedUrl();
+        expect(url).to.include('autoplay=1');
+        expect(url).to.not.include('mute=1');
+        expect(url).to.include('controls=1');
+        expect(url).to.not.include('modestbranding=1');
+      });
+    });
+
+    describe('createVideoSection', () => {
+      beforeEach(() => {
+        youtubeChat.videoId = 'dQw4w9WgXcQ';
+        youtubeChat.config = {
+          videotitle: 'Custom Video Title',
+          autoplay: 'true',
+          mute: 'true'
+        };
+      });
+
+      it('should create video section with correct structure', () => {
+        const videoSection = youtubeChat.createVideoSection();
+        
+        expect(videoSection.classList.contains('youtube-video-container')).to.be.true;
+        
+        const iframeContainer = videoSection.querySelector('.iframe-container');
+        expect(iframeContainer).to.not.be.null;
+        
+        const iframe = iframeContainer.querySelector('.youtube-video');
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.getAttribute('title')).to.equal('Custom Video Title');
+        expect(iframe.getAttribute('loading')).to.equal('lazy');
+        expect(iframe.getAttribute('allowfullscreen')).to.equal('true');
+      });
+
+      it('should use default title when not provided', () => {
+        delete youtubeChat.config.videotitle;
+        
+        const videoSection = youtubeChat.createVideoSection();
+        const iframe = videoSection.querySelector('.youtube-video');
+        
+        expect(iframe.getAttribute('title')).to.equal('YouTube video player');
+      });
+    });
+
+    describe('createChatSection', () => {
+      beforeEach(() => {
+        youtubeChat.videoId = 'dQw4w9WgXcQ';
+      });
+
+      it('should create chat section with correct structure', () => {
+        const chatSection = youtubeChat.createChatSection();
+        
+        expect(chatSection.classList.contains('youtube-chat-container')).to.be.true;
+        
+        const iframeContainer = chatSection.querySelector('.iframe-container');
+        expect(iframeContainer).to.not.be.null;
+        
+        const iframe = iframeContainer.querySelector('.youtube-chat');
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.getAttribute('title')).to.equal('YouTube live chat');
+        expect(iframe.getAttribute('loading')).to.equal('lazy');
+        expect(iframe.getAttribute('src')).to.include('https://www.youtube.com/live_chat?v=dQw4w9WgXcQ');
+        expect(iframe.getAttribute('src')).to.include('embed_domain=');
+      });
+    });
+
+    describe('buildYouTubeStream', () => {
+      beforeEach(() => {
+        youtubeChat.videoId = 'dQw4w9WgXcQ';
+        youtubeChat.config = { videotitle: 'Test Video' };
+      });
+
+      it('should build stream with chat when enabled', () => {
+        youtubeChat.chatEnabled = true;
+        
+        const stream = youtubeChat.buildYouTubeStream();
+        
+        expect(stream.classList.contains('youtube-stream')).to.be.true;
+        expect(stream.classList.contains('single-column')).to.be.false;
+        
+        const videoContainer = stream.querySelector('.youtube-video-container');
+        expect(videoContainer).to.not.be.null;
+        
+        const chatContainer = stream.querySelector('.youtube-chat-container');
+        expect(chatContainer).to.not.be.null;
+      });
+
+      it('should build stream without chat when disabled', () => {
+        youtubeChat.chatEnabled = false;
+        
+        const stream = youtubeChat.buildYouTubeStream();
+        
+        expect(stream.classList.contains('youtube-stream')).to.be.true;
+        expect(stream.classList.contains('single-column')).to.be.true;
+        
+        const videoContainer = stream.querySelector('.youtube-video-container');
+        expect(videoContainer).to.not.be.null;
+        
+        const chatContainer = stream.querySelector('.youtube-chat-container');
+        expect(chatContainer).to.be.null;
+      });
+    });
+  });
+
+  describe('init function (backward compatibility)', () => {
     it('should initialize YouTube chat with video and chat enabled', async () => {
       document.body.innerHTML = defaultHtml;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       // Verify that the block content was cleared
       expect(block.textContent).to.equal('');
-
+      
       // Verify that a container was created
       const container = block.querySelector('.youtube-stream');
       expect(container).to.not.be.null;
-
+      
       // Verify that both video and chat containers were created
       const videoContainer = container.querySelector('.youtube-video-container');
       expect(videoContainer).to.not.be.null;
-
+      
       const chatContainer = container.querySelector('.youtube-chat-container');
       expect(chatContainer).to.not.be.null;
-
+      
       // Verify that iframes were created
       const videoIframe = videoContainer.querySelector('.youtube-video');
       expect(videoIframe).to.not.be.null;
       expect(videoIframe.tagName).to.equal('IFRAME');
-
+      
       const chatIframe = chatContainer.querySelector('.youtube-chat');
       expect(chatIframe).to.not.be.null;
       expect(chatIframe.tagName).to.equal('IFRAME');
@@ -72,26 +235,26 @@ describe('YouTube Chat Module', () => {
           </div>
         </div>
       `;
-
+      
       document.body.innerHTML = htmlWithoutChat;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       // Verify that the block content was cleared
       expect(block.textContent).to.equal('');
-
+      
       // Verify that a container was created
       const container = block.querySelector('.youtube-stream');
       expect(container).to.not.be.null;
-
+      
       // Verify that single-column class was added
       expect(container.classList.contains('single-column')).to.be.true;
-
+      
       // Verify that only video container was created
       const videoContainer = container.querySelector('.youtube-video-container');
       expect(videoContainer).to.not.be.null;
-
+      
       const chatContainer = container.querySelector('.youtube-chat-container');
       expect(chatContainer).to.be.null;
     });
@@ -110,12 +273,12 @@ describe('YouTube Chat Module', () => {
           </div>
         </div>
       `;
-
+      
       document.body.innerHTML = htmlWithoutVideoId;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       // Verify that the block was removed from DOM
       expect(document.querySelector('.youtube-chat')).to.be.null;
     });
@@ -125,30 +288,30 @@ describe('YouTube Chat Module', () => {
     it('should create proper nested DOM structure', async () => {
       document.body.innerHTML = defaultHtml;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       // Verify the complete DOM structure
       const container = block.querySelector('.youtube-stream');
       expect(container).to.not.be.null;
-
+      
       // Video structure
       const videoWrapper = container.querySelector('.youtube-video-container');
       expect(videoWrapper).to.not.be.null;
-
+      
       const videoContainer = videoWrapper.querySelector('.iframe-container');
       expect(videoContainer).to.not.be.null;
-
+      
       const videoIframe = videoContainer.querySelector('.youtube-video');
       expect(videoIframe).to.not.be.null;
-
+      
       // Chat structure
       const chatWrap = container.querySelector('.youtube-chat-container');
       expect(chatWrap).to.not.be.null;
-
+      
       const chatContainer = chatWrap.querySelector('.iframe-container');
       expect(chatContainer).to.not.be.null;
-
+      
       const chatIframe = chatContainer.querySelector('.youtube-chat');
       expect(chatIframe).to.not.be.null;
     });
@@ -175,20 +338,20 @@ describe('YouTube Chat Module', () => {
           </div>
         </div>
       `;
-
+      
       document.body.innerHTML = htmlWithoutChat;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       const container = block.querySelector('.youtube-stream');
       expect(container).to.not.be.null;
       expect(container.classList.contains('single-column')).to.be.true;
-
+      
       // Should only have video structure
       const videoWrapper = container.querySelector('.youtube-video-container');
       expect(videoWrapper).to.not.be.null;
-
+      
       const chatWrap = container.querySelector('.youtube-chat-container');
       expect(chatWrap).to.be.null;
     });
@@ -198,12 +361,12 @@ describe('YouTube Chat Module', () => {
     it('should build video URL with parameters', async () => {
       document.body.innerHTML = defaultHtml;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       const videoIframe = block.querySelector('.youtube-video');
       expect(videoIframe).to.not.be.null;
-
+      
       const src = videoIframe.getAttribute('src');
       expect(src).to.include('https://www.youtube.com/embed/dQw4w9WgXcQ');
       expect(src).to.include('autoplay=1');
@@ -215,12 +378,12 @@ describe('YouTube Chat Module', () => {
     it('should build chat URL with correct parameters', async () => {
       document.body.innerHTML = defaultHtml;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       const chatIframe = block.querySelector('.youtube-chat');
       expect(chatIframe).to.not.be.null;
-
+      
       const src = chatIframe.getAttribute('src');
       expect(src).to.include('https://www.youtube.com/live_chat?v=dQw4w9WgXcQ');
       expect(src).to.include('embed_domain=');
@@ -250,15 +413,15 @@ describe('YouTube Chat Module', () => {
           </div>
         </div>
       `;
-
+      
       document.body.innerHTML = htmlWithAutoplayDisabled;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       const videoIframe = block.querySelector('.youtube-video');
       expect(videoIframe).to.not.be.null;
-
+      
       const src = videoIframe.getAttribute('src');
       expect(src).to.not.include('autoplay=1');
       expect(src).to.include('mute=1');
@@ -286,15 +449,15 @@ describe('YouTube Chat Module', () => {
           </div>
         </div>
       `;
-
+      
       document.body.innerHTML = htmlWithMuteDisabled;
       const block = document.querySelector('.youtube-chat');
-
+      
       await init(block);
-
+      
       const videoIframe = block.querySelector('.youtube-video');
       expect(videoIframe).to.not.be.null;
-
+      
       const src = videoIframe.getAttribute('src');
       expect(src).to.include('autoplay=1');
       expect(src).to.not.include('mute=1');

--- a/test/unit/blocks/youtube-chat/youtube-chat.test.js
+++ b/test/unit/blocks/youtube-chat/youtube-chat.test.js
@@ -1,0 +1,303 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { readFile } from '@web/test-runner-commands';
+import init from '../../../../events/blocks/youtube-chat/youtube-chat.js';
+
+const defaultHtml = await readFile({ path: './mocks/default.html' });
+
+describe('YouTube Chat Module', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // Reset DOM
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('init', () => {
+    it('should initialize YouTube chat with video and chat enabled', async () => {
+      document.body.innerHTML = defaultHtml;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      // Verify that the block content was cleared
+      expect(block.textContent).to.equal('');
+
+      // Verify that a container was created
+      const container = block.querySelector('.youtube-stream');
+      expect(container).to.not.be.null;
+
+      // Verify that both video and chat containers were created
+      const videoContainer = container.querySelector('.youtube-video-container');
+      expect(videoContainer).to.not.be.null;
+
+      const chatContainer = container.querySelector('.youtube-chat-container');
+      expect(chatContainer).to.not.be.null;
+
+      // Verify that iframes were created
+      const videoIframe = videoContainer.querySelector('.youtube-video');
+      expect(videoIframe).to.not.be.null;
+      expect(videoIframe.tagName).to.equal('IFRAME');
+
+      const chatIframe = chatContainer.querySelector('.youtube-chat');
+      expect(chatIframe).to.not.be.null;
+      expect(chatIframe.tagName).to.equal('IFRAME');
+    });
+
+    it('should initialize YouTube stream without chat when chatenabled is false', async () => {
+      // Create HTML with chatenabled set to false
+      const htmlWithoutChat = `
+        <div class="youtube-chat">
+          <div>
+            <div>videoid</div>
+            <div>dQw4w9WgXcQ</div>
+          </div>
+          <div>
+            <div>chatenabled</div>
+            <div>false</div>
+          </div>
+          <div>
+            <div>autoplay</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>mute</div>
+            <div>true</div>
+          </div>
+        </div>
+      `;
+
+      document.body.innerHTML = htmlWithoutChat;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      // Verify that the block content was cleared
+      expect(block.textContent).to.equal('');
+
+      // Verify that a container was created
+      const container = block.querySelector('.youtube-stream');
+      expect(container).to.not.be.null;
+
+      // Verify that single-column class was added
+      expect(container.classList.contains('single-column')).to.be.true;
+
+      // Verify that only video container was created
+      const videoContainer = container.querySelector('.youtube-video-container');
+      expect(videoContainer).to.not.be.null;
+
+      const chatContainer = container.querySelector('.youtube-chat-container');
+      expect(chatContainer).to.be.null;
+    });
+
+    it('should not initialize when videoId is missing', async () => {
+      // Create HTML without videoId
+      const htmlWithoutVideoId = `
+        <div class="youtube-chat">
+          <div>
+            <div>chatenabled</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>autoplay</div>
+            <div>true</div>
+          </div>
+        </div>
+      `;
+
+      document.body.innerHTML = htmlWithoutVideoId;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      // Verify that the block was removed from DOM
+      expect(document.querySelector('.youtube-chat')).to.be.null;
+    });
+  });
+
+  describe('DOM structure', () => {
+    it('should create proper nested DOM structure', async () => {
+      document.body.innerHTML = defaultHtml;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      // Verify the complete DOM structure
+      const container = block.querySelector('.youtube-stream');
+      expect(container).to.not.be.null;
+
+      // Video structure
+      const videoWrapper = container.querySelector('.youtube-video-container');
+      expect(videoWrapper).to.not.be.null;
+
+      const videoContainer = videoWrapper.querySelector('.iframe-container');
+      expect(videoContainer).to.not.be.null;
+
+      const videoIframe = videoContainer.querySelector('.youtube-video');
+      expect(videoIframe).to.not.be.null;
+
+      // Chat structure
+      const chatWrap = container.querySelector('.youtube-chat-container');
+      expect(chatWrap).to.not.be.null;
+
+      const chatContainer = chatWrap.querySelector('.iframe-container');
+      expect(chatContainer).to.not.be.null;
+
+      const chatIframe = chatContainer.querySelector('.youtube-chat');
+      expect(chatIframe).to.not.be.null;
+    });
+
+    it('should create single-column structure when chat is disabled', async () => {
+      // Create HTML with chatenabled set to false
+      const htmlWithoutChat = `
+        <div class="youtube-chat">
+          <div>
+            <div>videoid</div>
+            <div>dQw4w9WgXcQ</div>
+          </div>
+          <div>
+            <div>chatenabled</div>
+            <div>false</div>
+          </div>
+          <div>
+            <div>autoplay</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>mute</div>
+            <div>true</div>
+          </div>
+        </div>
+      `;
+
+      document.body.innerHTML = htmlWithoutChat;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      const container = block.querySelector('.youtube-stream');
+      expect(container).to.not.be.null;
+      expect(container.classList.contains('single-column')).to.be.true;
+
+      // Should only have video structure
+      const videoWrapper = container.querySelector('.youtube-video-container');
+      expect(videoWrapper).to.not.be.null;
+
+      const chatWrap = container.querySelector('.youtube-chat-container');
+      expect(chatWrap).to.be.null;
+    });
+  });
+
+  describe('URL generation', () => {
+    it('should build video URL with parameters', async () => {
+      document.body.innerHTML = defaultHtml;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      const videoIframe = block.querySelector('.youtube-video');
+      expect(videoIframe).to.not.be.null;
+
+      const src = videoIframe.getAttribute('src');
+      expect(src).to.include('https://www.youtube.com/embed/dQw4w9WgXcQ');
+      expect(src).to.include('autoplay=1');
+      expect(src).to.include('mute=1');
+      expect(src).to.include('controls=1');
+      expect(src).to.include('modestbranding=1');
+    });
+
+    it('should build chat URL with correct parameters', async () => {
+      document.body.innerHTML = defaultHtml;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      const chatIframe = block.querySelector('.youtube-chat');
+      expect(chatIframe).to.not.be.null;
+
+      const src = chatIframe.getAttribute('src');
+      expect(src).to.include('https://www.youtube.com/live_chat?v=dQw4w9WgXcQ');
+      expect(src).to.include('embed_domain=');
+    });
+  });
+
+  describe('Configuration options', () => {
+    it('should handle different autoplay settings', async () => {
+      // Create HTML with autoplay disabled
+      const htmlWithAutoplayDisabled = `
+        <div class="youtube-chat">
+          <div>
+            <div>videoid</div>
+            <div>dQw4w9WgXcQ</div>
+          </div>
+          <div>
+            <div>chatenabled</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>autoplay</div>
+            <div>false</div>
+          </div>
+          <div>
+            <div>mute</div>
+            <div>true</div>
+          </div>
+        </div>
+      `;
+
+      document.body.innerHTML = htmlWithAutoplayDisabled;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      const videoIframe = block.querySelector('.youtube-video');
+      expect(videoIframe).to.not.be.null;
+
+      const src = videoIframe.getAttribute('src');
+      expect(src).to.not.include('autoplay=1');
+      expect(src).to.include('mute=1');
+    });
+
+    it('should handle different mute settings', async () => {
+      // Create HTML with mute disabled
+      const htmlWithMuteDisabled = `
+        <div class="youtube-chat">
+          <div>
+            <div>videoid</div>
+            <div>dQw4w9WgXcQ</div>
+          </div>
+          <div>
+            <div>chatenabled</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>autoplay</div>
+            <div>true</div>
+          </div>
+          <div>
+            <div>mute</div>
+            <div>false</div>
+          </div>
+        </div>
+      `;
+
+      document.body.innerHTML = htmlWithMuteDisabled;
+      const block = document.querySelector('.youtube-chat');
+
+      await init(block);
+
+      const videoIframe = block.querySelector('.youtube-video');
+      expect(videoIframe).to.not.be.null;
+
+      const src = videoIframe.getAttribute('src');
+      expect(src).to.include('autoplay=1');
+      expect(src).to.not.include('mute=1');
+    });
+  });
+});


### PR DESCRIPTION
Added support for displaying YouTube Chat next to the embedded YouTube Player block. This allows users to view and participate in the live chat directly within the MILO page.

Resolves: https://jira.corp.adobe.com/browse/MWPW-174658

Test URLs:
- Before: https://main--events-milo--adobecom.aem.live/drafts/hnv/youtube-chat-test
- After: https://youtube-chat-dev--events-milo--adobecom.aem.live/drafts/hnv/youtube-chat-test

Sample Authoring page:- https://adobe.sharepoint.com/:w:/r/sites/acomevents/_layouts/15/Doc.aspx?sourcedoc=%7B9584D062-49B8-4D07-AC98-4F5771C5C806%7D&file=youtube-chat-test.docx&action=default&mobileredirect=true

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
