### PR TITLE
Removing fstab mapping and related sitemap changes

### DIFF
--- a/events/create-now/sitemap-index.xml
+++ b/events/create-now/sitemap-index.xml
@@ -13,24 +13,6 @@
     <loc>https://www.adobe.com/de/events/create-now/events-sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/fr/events/create-now/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/fr/events/create-now/events-sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/es/events/create-now/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/es/events/create-now/events-sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/th_en/events/create-now/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/th_en/events/create-now/events-sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://www.adobe.com/uk/events/create-now/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -9,7 +9,4 @@ mountpoints:
 folders:
   /events: /events/default
   /de/events: /de/events/default
-  /fr/events: /fr/events/default
   /uk/events: /uk/events/default
-  /es/events: /es/events/default
-  /th_en/events: /th_en/events/default

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -33,28 +33,9 @@ indices:
       - '/de/events/**'
     target: /de/events/query-index.xlsx
 
-  fr:
-    <<: *website
-    include:
-      - '/fr/events/**'
-    target: /fr/events/query-index.xlsx
-
   uk:
     <<: *website
     include:
       - '/uk/events/**'
     target: /uk/events/query-index.xlsx
-
-  es:
-    <<: *website
-    include:
-      - '/es/events/**'
-    target: /es/events/query-index.xlsx
-
-  th_en:
-    <<: *website
-    include:
-      - '/th_en/events/**'
-    target: /th_en/events/query-index.xlsx
-
   

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -13,21 +13,6 @@ sitemaps:
         destination: /de/events/create-now/sitemap.xml
         hreflang: de
         alternate: /de/{path}
-      fr:
-        source: /fr/events/query-index.json
-        destination: /fr/events/create-now/sitemap.xml
-        hreflang: fr
-        alternate: /fr/{path}
-      es:
-        source: /es/events/query-index.json
-        destination: /es/events/create-now/sitemap.xml
-        hreflang: es
-        alternate: /es/{path}
-      th_en:
-        source: /th_en/events/query-index.json
-        destination: /th_en/events/create-now/sitemap.xml
-        hreflang: th-EN
-        alternate: /th_en/{path}
       uk:
         source: /uk/events/query-index.json
         destination: /uk/events/create-now/sitemap.xml
@@ -47,21 +32,6 @@ sitemaps:
         destination: /de/events/create-now/events-sitemap.xml
         hreflang: de
         alternate: /de/{path}
-      fr:
-        source: /fr/events/default/metadata.json?sheet=sitemap
-        destination: /fr/events/create-now/events-sitemap.xml
-        hreflang: fr
-        alternate: /fr/{path}
-      es:
-        source: /es/events/default/metadata.json?sheet=sitemap
-        destination: /es/events/create-now/events-sitemap.xml
-        hreflang: es
-        alternate: /es/{path}
-      th_en:
-        source: /th_en/events/default/metadata.json?sheet=sitemap
-        destination: /th_en/events/create-now/events-sitemap.xml
-        hreflang: th-EN
-        alternate: /th_en/{path}
       uk:
         source: /uk/events/default/metadata.json?sheet=sitemap
         destination: /uk/events/create-now/events-sitemap.xml


### PR DESCRIPTION
Resolves: [MWPW-177123](https://jira.corp.adobe.com/browse/MWPW-177123)

Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
