### PR TITLE
[MWPW-172648]:- Changed script source URL for Mobile Rider player

### DIFF
--- a/events/blocks/mobile-rider/mobile-rider.js
+++ b/events/blocks/mobile-rider/mobile-rider.js
@@ -5,7 +5,7 @@ const { createTag, getConfig } = await import(`${LIBS}/utils/utils.js`);
 const CONFIG = {
   ANALYTICS: { PROVIDER: 'adobe' },
   SCRIPTS: {
-    DEV_URL: '//assets.mobilerider.com/p/player-adobe-dev/player.min.js',
+    DEV_URL: '//assets.mobilerider.com/p/player-adobe-integration/player.min.js',
     PROD_URL: '//assets.mobilerider.com/p/adobe/player.min.js',
   },
   PLAYER: {


### PR DESCRIPTION
Mobile Rider player script URL path update.

Resolves: https://jira.corp.adobe.com/browse/MWPW-172648

Test URLs:
- Before: https://main--events-milo--adobecom.aem.page/drafts/hnv/test-mobile-rider-concurrent
- After: https://mobile-rider-script--events-milo--adobecom.aem.page/drafts/hnv/test-mobile-rider-concurrent

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
