### PR TITLE
Remove primary button CSS override

### DIFF
--- a/events/styles/styles.css
+++ b/events/styles/styles.css
@@ -18,7 +18,6 @@ main a.con-button.no-event {
   opacity: 0.5;
 }
 
-a.con-button.blue,
 a.con-button.black {
   border: 2px solid var(--color-gray-800);
   background-color: var(--color-gray-800);
@@ -26,8 +25,8 @@ a.con-button.black {
   transition: background-color 0.2s, border-color 0.2s;
 }
 
-a.con-button.blue:hover,
-a.con-button.blue:focus {
+a.con-button.black:hover,
+a.con-button.black:focus {
   border: 2px solid var(--color-black);
   background-color: var(--color-black);
 }
@@ -40,7 +39,7 @@ a.con-button.rsvp-btn {
 }
 
 /* FIXME: workaround for fill button */
-.dark a.con-button.blue {
+.dark a.con-button.black {
   border: 2px solid var(--color-white);
   background-color: var(--color-white);
   opacity: 0.9;
@@ -48,8 +47,8 @@ a.con-button.rsvp-btn {
   transition: opacity 0.2s;
 }
 
-.dark a.con-button.blue:hover,
-.dark a.con-button.blue:focus {
+.dark a.con-button.black:hover,
+.dark a.con-button.black:focus {
   opacity: 1;
 }
 


### PR DESCRIPTION
This update relinquishes our changes overriding the blue primary button on our page. The template docs have all be previewed/published again with the authoring approach (#_button-fill) to render black fill button. With this fix, the geo-routing modal will render with the standard S2 blue button rather than our black button.

Resolves: 
https://jira.corp.adobe.com/browse/MWPW-177299

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.page/de/events
- After: https://primary-button-color--events-milo--adobecom.aem.page/de/events

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
