### PR TITLE
Fixing plugin name references

### DIFF
--- a/events/blocks/chrono-box/chrono-box.js
+++ b/events/blocks/chrono-box/chrono-box.js
@@ -33,9 +33,16 @@ function getSchedule(scheduleId) {
 }
 
 async function initPlugins(schedule) {
-  const SUPPORTED_PLUGINS = ['mobile-rider', 'metadata'];
-  const pluginsNeeded = SUPPORTED_PLUGINS.filter((plugin) => schedule.some((item) => item[plugin]));
-  const plugins = await Promise.all(pluginsNeeded.map((plugin) => import(`../../features/timing-framework/plugins/${plugin}/plugin.js`)));
+  const PLUGINS_MAP = {
+    mobileRider: 'mobile-rider',
+    metadata: 'metadata',
+  };
+  const hasPlugin = (plugin) => schedule.some((item) => item[plugin]);
+  const pluginsNeeded = Object.keys(PLUGINS_MAP).filter(hasPlugin);
+  const plugins = await Promise.all(pluginsNeeded.map((plugin) => {
+    const pluginDir = PLUGINS_MAP[plugin];
+    return import(`../../features/timing-framework/plugins/${pluginDir}/plugin.js`);
+  }));
 
   // Get or create a global tabId that's shared across all chrono-boxes on this page
   // This ensures that multiple chrono-boxes on the same page use the same tabId,
@@ -48,7 +55,7 @@ async function initPlugins(schedule) {
 
   const pluginsModules = new Map();
   await Promise.all(plugins.map(async (plugin, index) => {
-    const pluginName = pluginsNeeded[index].replace('-', '');
+    const pluginName = pluginsNeeded[index];
     pluginsModules.set(pluginName, await plugin.default(schedule));
   }));
 

--- a/test-manual.html
+++ b/test-manual.html
@@ -101,7 +101,7 @@
                             title: 'Session 1',
                             pathToFragment: '/fragment-1',
                             metadata: [{ key: 'video.url' }],
-                            'mobile-rider': [{ sessionId: 'session-1' }]
+                            'mobileRider': [{ sessionId: 'session-1' }]
                         }
                     ],
                     'test-schedule-2': [
@@ -110,7 +110,7 @@
                             title: 'Session 2',
                             pathToFragment: '/fragment-2',
                             metadata: [{ key: 'speaker.name' }],
-                            'mobile-rider': [{ sessionId: 'session-2' }]
+                            'mobileRider': [{ sessionId: 'session-2' }]
                         }
                     ]
                 });
@@ -172,7 +172,7 @@
                 const schedule = [
                     {
                         metadata: [{ key: 'video.url' }],
-                        'mobile-rider': [{ sessionId: 'test-session' }]
+                        'mobileRider': [{ sessionId: 'test-session' }]
                     }
                 ];
                 const tabId = window.crypto.randomUUID();

--- a/test-multiple-chronoboxes.html
+++ b/test-multiple-chronoboxes.html
@@ -96,7 +96,7 @@
                             title: 'Session 1',
                             pathToFragment: '/fragment-1',
                             metadata: [{ key: 'video.url' }],
-                            'mobile-rider': [{ sessionId: 'session-1' }]
+                            'mobileRider': [{ sessionId: 'session-1' }]
                         }
                     ],
                     'test-schedule-2': [
@@ -105,7 +105,7 @@
                             title: 'Session 2',
                             pathToFragment: '/fragment-2',
                             metadata: [{ key: 'speaker.name' }],
-                            'mobile-rider': [{ sessionId: 'session-2' }]
+                            'mobileRider': [{ sessionId: 'session-2' }]
                         }
                     ]
                 });
@@ -141,13 +141,13 @@
                 const schedule1 = [
                     {
                         metadata: [{ key: 'video.url' }],
-                        'mobile-rider': [{ sessionId: 'session-1' }]
+                        'mobileRider': [{ sessionId: 'session-1' }]
                     }
                 ];
                 const schedule2 = [
                     {
                         metadata: [{ key: 'speaker.name' }],
-                        'mobile-rider': [{ sessionId: 'session-2' }]
+                        'mobileRider': [{ sessionId: 'session-2' }]
                     }
                 ];
 


### PR DESCRIPTION
Cohort findings. There was a naming formatting error around timing framework plugins due to the path kebab format being mixed in with json camelCase without proper conversion.

Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
