### PR TITLE
[MWPW-174658] Youtube chat block enhancement

### DIFF
--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -182,8 +182,9 @@ export class YouTubeChat {
 
     if (autoplay || userInitiated) {
       params.append('autoplay', '1');
-      // Force mute only for browser autoplay, not for user-initiated play
-      if (autoplay && this.config.mute?.toLowerCase() !== 'false') {
+      // Force mute for browser autoplay (required by browsers)
+      // For user-initiated play, respect the user's mute preference
+      if (autoplay) {
         params.append('mute', '1');
       }
     }

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -185,6 +185,9 @@ export class YouTubeChat {
     }
 
     Object.entries(CONFIG.PLAYER_OPTIONS).forEach(([key, param]) => {
+      // Skip mute if autoplay is enabled since it's already added above
+      if (autoplay && key === 'mute') return;
+      
       if (this.config[key]?.toLowerCase?.() === 'true') {
         params.append(param, '1');
       }

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -89,7 +89,7 @@ export class YouTubeChat {
   }
 
   insertAutoplayIframe(wrapper) {
-    const iframe = this.createVideoIframe(this.buildEmbedUrl(true));
+    const iframe = this.createVideoIframe(this.buildEmbedUrl(true, false));
     wrapper.append(iframe);
     this.videoLoaded = true;
     if (this.chatEnabled) setTimeout(() => this.loadChat(), CONFIG.CHAT_LOAD_DELAY);
@@ -127,9 +127,8 @@ export class YouTubeChat {
       container.classList.remove('single-column');
     }
 
-    // When user clicks play, respect their mute preference
-    // Don't force autoplay=true since user is manually clicking play
-    const iframe = this.createVideoIframe(this.buildEmbedUrl(false));
+    // When user clicks play, start video immediately but respect their mute preference
+    const iframe = this.createVideoIframe(this.buildEmbedUrl(false, true));
     liteYT.insertAdjacentElement('afterend', iframe);
     liteYT.remove();
 
@@ -177,15 +176,14 @@ export class YouTubeChat {
     return this.config.autoplay?.toLowerCase() === 'true';
   }
 
-  buildEmbedUrl(autoplay = false) {
+  buildEmbedUrl(autoplay = false, userInitiated = false) {
     const base = `${CONFIG.YOUTUBE_EMBED_BASE}/${this.videoId}`;
     const params = new URLSearchParams();
 
-    if (autoplay) {
+    if (autoplay || userInitiated) {
       params.append('autoplay', '1');
-      // Only force mute if autoplay is enabled and user hasn't explicitly set mute to false
-      const shouldMute = this.config.mute?.toLowerCase() !== 'false';
-      if (shouldMute) {
+      // Force mute only for browser autoplay, not for user-initiated play
+      if (autoplay && this.config.mute?.toLowerCase() !== 'false') {
         params.append('mute', '1');
       }
     }

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -127,7 +127,9 @@ export class YouTubeChat {
       container.classList.remove('single-column');
     }
 
-    const iframe = this.createVideoIframe(this.buildEmbedUrl(true));
+    // When user clicks play, respect their mute preference
+    // Don't force autoplay=true since user is manually clicking play
+    const iframe = this.createVideoIframe(this.buildEmbedUrl(false));
     liteYT.insertAdjacentElement('afterend', iframe);
     liteYT.remove();
 
@@ -181,11 +183,15 @@ export class YouTubeChat {
 
     if (autoplay) {
       params.append('autoplay', '1');
-      params.append('mute', '1');
+      // Only force mute if autoplay is enabled and user hasn't explicitly set mute to false
+      const shouldMute = this.config.mute?.toLowerCase() !== 'false';
+      if (shouldMute) {
+        params.append('mute', '1');
+      }
     }
 
     Object.entries(CONFIG.PLAYER_OPTIONS).forEach(([key, param]) => {
-      // Skip mute if autoplay is enabled since it's already added above
+      // Skip mute if autoplay is enabled since it's already handled above
       if (autoplay && key === 'mute') return;
       
       if (this.config[key]?.toLowerCase?.() === 'true') {

--- a/events/blocks/youtube-chat/youtube-chat.js
+++ b/events/blocks/youtube-chat/youtube-chat.js
@@ -127,7 +127,7 @@ export class YouTubeChat {
       container.classList.remove('single-column');
     }
 
-    // When user clicks play, start video immediately but respect their mute preference
+    // When user clicks play, start video immediately but respect author's mute preference
     const iframe = this.createVideoIframe(this.buildEmbedUrl(false, true));
     liteYT.insertAdjacentElement('afterend', iframe);
     liteYT.remove();

--- a/test/unit/blocks/youtube-chat/youtube-chat.test.js
+++ b/test/unit/blocks/youtube-chat/youtube-chat.test.js
@@ -70,24 +70,71 @@ describe('YouTube Chat Module', () => {
         youtubeChat.videoId = 'dQw4w9WgXcQ';
       });
 
-      it('should build embed URL with correct parameters', () => {
+      it('should build embed URL with correct parameters for browser autoplay', () => {
         youtubeChat.config = {
           'show-controls': 'true',
           'show-player-title-actions': 'true',
+          mute: 'true',
         };
 
-        const autoplayUrl = youtubeChat.buildEmbedUrl(true);
+        const autoplayUrl = youtubeChat.buildEmbedUrl(true, false);
         expect(autoplayUrl).to.include('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
         expect(autoplayUrl).to.include('autoplay=1');
         expect(autoplayUrl).to.include('mute=1');
         expect(autoplayUrl).to.include('controls=1');
         expect(autoplayUrl).to.include('modestbranding=1');
+      });
 
-        const noAutoplayUrl = youtubeChat.buildEmbedUrl(false);
+      it('should build embed URL with correct parameters for user-initiated play', () => {
+        youtubeChat.config = {
+          'show-controls': 'true',
+          'show-player-title-actions': 'true',
+          mute: 'true',
+        };
+
+        const userInitiatedUrl = youtubeChat.buildEmbedUrl(false, true);
+        expect(userInitiatedUrl).to.include('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+        expect(userInitiatedUrl).to.include('autoplay=1');
+        expect(userInitiatedUrl).to.include('mute=1');
+        expect(userInitiatedUrl).to.include('controls=1');
+        expect(userInitiatedUrl).to.include('modestbranding=1');
+      });
+
+      it('should build embed URL without autoplay for regular load', () => {
+        youtubeChat.config = {
+          'show-controls': 'true',
+          'show-player-title-actions': 'true',
+        };
+
+        const noAutoplayUrl = youtubeChat.buildEmbedUrl(false, false);
         expect(noAutoplayUrl).to.include('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
         expect(noAutoplayUrl).to.not.include('autoplay=1');
         expect(noAutoplayUrl).to.not.include('mute=1');
         expect(noAutoplayUrl).to.include('controls=1');
+      });
+
+      it('should respect mute config for user-initiated play when mute is false', () => {
+        youtubeChat.config = {
+          mute: 'false',
+          'show-controls': 'true',
+        };
+
+        const userInitiatedUrl = youtubeChat.buildEmbedUrl(false, true);
+        expect(userInitiatedUrl).to.include('autoplay=1');
+        expect(userInitiatedUrl).to.not.include('mute=1');
+        expect(userInitiatedUrl).to.include('controls=1');
+      });
+
+      it('should force mute for browser autoplay even when mute config is false', () => {
+        youtubeChat.config = {
+          mute: 'false',
+          'show-controls': 'true',
+        };
+
+        const autoplayUrl = youtubeChat.buildEmbedUrl(true, false);
+        expect(autoplayUrl).to.include('autoplay=1');
+        expect(autoplayUrl).to.include('mute=1'); // Forced for browser autoplay
+        expect(autoplayUrl).to.include('controls=1');
       });
     });
 


### PR DESCRIPTION
Added userInitiated parameter to distinguish between browser autoplay and user clicks
Browser Autoplay (autoplay=true, userInitiated=false): Always forces mute=1 (browser requirement)
User-Initiated Play (autoplay=false, userInitiated=true): Respects author's mute preference

Resolves: https://jira.corp.adobe.com/browse/MWPW-174658

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.page/drafts/hnv/youtube-chat-test
- After: https://test-mute-youtube--events-milo--adobecom.aem.page/drafts/hnv/youtube-chat-test

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
