### PR TITLE
Add GitHub Actions workflows for E2E testing

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,152 @@
+name: E2E Tests
+on:
+  push:
+    branches:
+      - dev
+      - stage
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - stage
+      - main
+  workflow_dispatch:
+    inputs:
+      test_environment:
+        description: 'Environment to test against'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - stage
+          - prod
+      test_suite:
+        description: 'Test suite to run'
+        required: true
+        default: '@smoke'
+        type: choice
+        options:
+          - '@smoke'
+          - '@regression'
+          - '@smoke or @regression'
+      test_jobs:
+        description: 'Browser jobs to run'
+        required: true
+        default: 'chrome-desktop'
+        type: choice
+        options:
+          - chrome-desktop
+          - firefox-desktop
+          - all
+      source_branch:
+        description: 'Source branch for testing'
+        required: false
+        type: string
+
+jobs:
+  # ============================================================================
+  # MANUAL TESTING
+  # ============================================================================
+  
+  # Event  : Manual workflow dispatch
+  # Action : Run tests based on user inputs
+  manual-test:
+    uses: ./.github/workflows/trigger-circleci.yml
+    if: github.event_name == 'workflow_dispatch'
+    secrets:
+      CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+    with:
+      environment: ${{ github.event.inputs.test_environment }}
+      test_suite: ${{ github.event.inputs.test_suite }}
+      test_jobs: ${{ github.event.inputs.test_jobs }}
+      ecbranch: ${{ github.event.inputs.source_branch || github.ref_name }}
+      milobranch: main
+      job_name: Manual Test - ${{ github.event.inputs.test_environment }} Environment
+
+  # ============================================================================
+  # DEV WORKFLOW
+  # ============================================================================
+  
+  # Event  : When a PR is merged to dev branch
+  # Action : Run smoke tests on dev environment
+  dev-smoke-tests:
+    uses: ./.github/workflows/trigger-circleci.yml
+    if: github.event_name == 'push' && github.ref_name == 'dev'
+    secrets:
+      CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+    with:
+      environment: dev
+      test_suite: '@smoke'
+      test_jobs: chrome-desktop
+      ecbranch: ${{ github.head_ref || github.ref_name }}
+      milobranch: main
+      job_name: Dev Smoke Tests
+
+  # ============================================================================
+  # STAGE WORKFLOW
+  # ============================================================================
+  
+  # Event  : When a PR is opened for stage branch
+  # Action : Run full test suite on dev environment
+  dev-full-tests-stage-pr:
+    uses: ./.github/workflows/trigger-circleci.yml
+    if: github.event_name == 'pull_request' && github.base_ref == 'stage'
+    secrets:
+      CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+    with:
+      environment: dev
+      test_suite: '@smoke or @regression'
+      test_jobs: chrome-desktop
+      ecbranch: ${{ github.head_ref || github.ref_name }}
+      milobranch: main
+      job_name: Dev Full Test Suite (Stage PR)
+
+  # Event  : When a PR is merged to stage branch
+  # Action : Run regression tests on stage environment
+  stage-regression-tests:
+    uses: ./.github/workflows/trigger-circleci.yml
+    if: github.event_name == 'push' && github.ref_name == 'stage'
+    secrets:
+      CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+    with:
+      environment: stage
+      test_suite: '@regression'
+      test_jobs: chrome-desktop
+      ecbranch: ${{ github.head_ref || github.ref_name }}
+      milobranch: main
+      job_name: Stage Regression Tests
+
+  # ============================================================================
+  # PRODUCTION WORKFLOW
+  # ============================================================================
+  
+  # Event  : When a PR is opened for main branch
+  # Action : Run full test suite on stage environment
+  stage-full-tests-main-pr:
+    uses: ./.github/workflows/trigger-circleci.yml
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    secrets:
+      CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+    with:
+      environment: stage
+      test_suite: '@smoke or @regression'
+      test_jobs: chrome-desktop
+      ecbranch: ${{ github.head_ref || github.ref_name }}
+      milobranch: main
+      job_name: Stage Full Test Suite (Main PR)
+
+  # Event  : When a PR is merged to main branch
+  # Action : Run regression tests on production environment
+  prod-regression-tests:
+    uses: ./.github/workflows/trigger-circleci.yml
+    if: github.event_name == 'push' && github.ref_name == 'main'
+    secrets:
+      CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+    with:
+      environment: prod
+      test_suite: '@regression'
+      test_jobs: chrome-desktop
+      ecbranch: ${{ github.head_ref || github.ref_name }}
+      milobranch: main
+      job_name: Prod Regression Tests

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -1,0 +1,70 @@
+name: Trigger CircleCI E2E Tests
+on:
+  workflow_call:
+    secrets:
+      CCI_TOKEN:
+        description: 'CircleCI API token'
+        required: true
+    inputs:
+      environment:
+        description: 'Target environment (dev, stage, prod)'
+        required: true
+        type: string
+      test_suite:
+        description: 'Test suite to run (@smoke, @regression, @smoke or @regression: full test suite)'
+        required: true
+        type: string
+      test_jobs:
+        description: 'Browser jobs to run (chrome-desktop, all, etc.)'
+        required: true
+        type: string
+      ecbranch:
+        description: 'Source branch for testing'
+        required: true
+        type: string
+      milobranch:
+        description: 'Milo branch for testing'
+        required: true
+        type: string
+        default: 'main'
+      job_name:
+        description: 'Display name for the job'
+        required: true
+        type: string
+
+jobs:
+  trigger-circleci:
+    name: ${{ inputs.job_name }}
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - name: Pass workflow event info
+        id: event-info
+        run: |
+          echo "event_name=${{ github.event_name }}" >> $GITHUB_OUTPUT
+          echo "pr_number=${{ github.event.pull_request.number || '' }}" >> $GITHUB_OUTPUT
+          echo "repository=${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "ref_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "base_ref=${{ github.event.pull_request.base.ref || '' }}" >> $GITHUB_OUTPUT
+          echo "head_ref=${{ github.event.pull_request.head.ref || '' }}" >> $GITHUB_OUTPUT
+
+      - name: Trigger CircleCI Pipeline
+        run: |
+          curl -X POST 'https://circle.ci.adobe.com/api/v2/project/gh/wcms/Platform-UI-EC/pipeline' \
+              -H 'Circle-Token: ${{ secrets.CCI_TOKEN }}' \
+              -H 'content-type: application/json' \
+              -d "{\"branch\":\"main\", \
+                    \"parameters\":{ \
+                      \"env\":\"${{ inputs.environment }}\", \
+                      \"project\":\"t3\", \
+                      \"test_suite\":\"${{ inputs.test_suite }}\", \
+                      \"test_jobs\":\"${{ inputs.test_jobs }}\", \
+                      \"ecbranch\":\"${{ inputs.ecbranch }}\", \
+                      \"milobranch\":\"${{ inputs.milobranch }}\", \
+                      \"event_name\":\"${{ steps.event-info.outputs.event_name }}\", \
+                      \"pr_number\":\"${{ steps.event-info.outputs.pr_number }}\", \
+                      \"repository\":\"${{ steps.event-info.outputs.repository }}\", \
+                      \"ref_name\":\"${{ steps.event-info.outputs.ref_name }}\", \
+                      \"base_ref\":\"${{ steps.event-info.outputs.base_ref }}\", \
+                      \"head_ref\":\"${{ steps.event-info.outputs.head_ref }}\" \
+                    } \
+              }" 


### PR DESCRIPTION
This is similar to the Github workflow for ECC Milo: https://github.com/adobecom/ecc-milo/pull/556

To prevent redundant executions, this repository will not have a daily scheduled test run unlike ECC Milo.

Also, we will use the 'repository' parameter in our test repo's CircleCI config to conditionally run the appropriate test suite (such as the event-details tests) for the code changes in this repo.

Test results will also be sent to [#milo-events-tests](https://adobe.enterprise.slack.com/archives/C07DLEN78V9).

