### PR TITLE
[MWPW-178581]:- TF MR Integration - Live stream ends early fails

### DIFF
--- a/events/blocks/mobile-rider/drawer.css
+++ b/events/blocks/mobile-rider/drawer.css
@@ -45,15 +45,17 @@
 }
 
 .mobile-rider .now-playing-title {
-  color: #fcfcfc;
+  color: #fff;
   margin: 0;
   font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 .mobile-rider .now-playing-subtitle {
   font-size: 12px;
   line-height: 1;
-  color: #fcfcfc;
+  color: #fff;
   font-weight: lighter;
 }
 

--- a/events/blocks/mobile-rider/drawer.css
+++ b/events/blocks/mobile-rider/drawer.css
@@ -45,7 +45,7 @@
 }
 
 .mobile-rider .now-playing-title {
-  color: #fff;
+  color: #fcfcfc;
   margin: 0;
   font-size: 12px;
 }
@@ -53,7 +53,7 @@
 .mobile-rider .now-playing-subtitle {
   font-size: 12px;
   line-height: 1;
-  color: #fff;
+  color: #fcfcfc;
   font-weight: lighter;
 }
 
@@ -128,7 +128,7 @@
   justify-content: center;
   padding: 0 0.75rem;
   min-width: 0;
-  width: 100%;
+  flex: 1;
 }
 
 .mobile-rider .drawer-item-title {
@@ -207,9 +207,7 @@
   }
 
   .mobile-rider .now-playing-title {
-    font-size: 12px;
     line-height: 1;
-    color: #fff;
     font-weight: lighter;
   }
 }

--- a/events/blocks/mobile-rider/drawer.css
+++ b/events/blocks/mobile-rider/drawer.css
@@ -68,14 +68,21 @@
   align-items: center;
 }
 
-.mobile-rider .drawer-item:hover, .mobile-rider .drawer-item.current {
+.mobile-rider .drawer-item.current {
   border-bottom: 3px solid #1473e6;
+}
+
+/* Blue background on hover only for non-current items */
+.mobile-rider .drawer-item:not(.current):hover {
+  background-color: #1473e6;
 }
 
 .mobile-rider .drawer-item-thumbnail {
   height: 45px;
   width: 74.66px;
   margin: 0;
+  border: 3px solid black;
+  position: relative;
 }
 
 .mobile-rider .drawer-item-thumbnail img {
@@ -83,8 +90,36 @@
   height: 100%;
   object-fit: cover;
   display: block;
-  border-radius: 4px;
-  border: 3px solid black;
+}
+
+/* Play button overlay */
+.mobile-rider .drawer-item:hover .drawer-item-thumbnail::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20px;
+  height: 20px;
+  background-color: #1473e6;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mobile-rider .drawer-item:hover .drawer-item-thumbnail::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 0;
+  height: 0;
+  border-left: 8px solid white;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  z-index: 1;
 }
 
 .mobile-rider .drawer-item-content {
@@ -121,6 +156,20 @@
   -webkit-box-orient: vertical;
   width: 100%;
   color: #FCFCFC;
+}
+
+/* Hover effects for current item */
+.mobile-rider .drawer-item.current .drawer-item-thumbnail {
+  border: 3px solid white;
+}
+
+.mobile-rider .drawer-item:not(.current):hover .drawer-item-thumbnail {
+  border: 3px solid white;
+}
+
+.mobile-rider .drawer-item.current:hover .drawer-item-title {
+  text-decoration: underline;
+  text-decoration-color: white;
 }
 
 @media (max-width: 768px) {

--- a/events/blocks/mobile-rider/drawer.js
+++ b/events/blocks/mobile-rider/drawer.js
@@ -61,8 +61,18 @@ class Drawer {
   setActiveById(id) {
     const el = this.itemsEl?.querySelector(`[data-id="${id}"]`);
     if (el) {
-      const item = this.items.find((i) => i.videoid === id);
-      if (item) this.setActive(el, item);
+      // Only update visual state, don't trigger click handler
+      this.itemsEl?.querySelectorAll('.drawer-item.current')
+        .forEach((i) => i.classList.remove('current'));
+      el.classList.add('current');
+    }
+  }
+
+  remove() {
+    // Remove the drawer element from the DOM
+    const drawerElement = this.root.querySelector('.drawer');
+    if (drawerElement) {
+      drawerElement.remove();
     }
   }
 }

--- a/events/blocks/mobile-rider/mobile-rider.css
+++ b/events/blocks/mobile-rider/mobile-rider.css
@@ -9,7 +9,16 @@
   margin: 0 auto;
   box-sizing: border-box;
 }
-    
+
+.mobile-rider .mobile-rider-container { position: relative; }
+
+.mobile-rider .mobile-rider-container .mr-poster {
+  position: absolute;
+  inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover; display: block;
+}
+
 .mobile-rider > :not(.mobile-rider-player) {
   display: none;
 }
@@ -30,4 +39,8 @@
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+.mobile-rider h2#title_container {
+  line-height: 1;
 }

--- a/events/blocks/mobile-rider/mobile-rider.js
+++ b/events/blocks/mobile-rider/mobile-rider.js
@@ -252,14 +252,11 @@ class MobileRider {
       Object.assign(con.dataset, { videoid: vid, skinid: skin, aslid: asl });
     }
 
-    // --- LCP: add poster preload + placeholder before we touch <video> -------
     const poster = this.cfg.poster || this.cfg.thumbnail;
     if (poster) {
       preloadPoster(poster);
     }
     const removePoster = showPosterPlaceholder(con, poster, this.cfg.title || 'Video poster');
-
-    // -------------------------------------------------------------------------
 
     window.__mr_player?.dispose();
     con.querySelector(`#${CONFIG.PLAYER.VIDEO_ID}`)?.remove();
@@ -268,8 +265,8 @@ class MobileRider {
       id: CONFIG.PLAYER.VIDEO_ID,
       class: CONFIG.PLAYER.VIDEO_CLASS,
       controls: true,
-      preload: 'metadata',       // LCP-friendly
-      playsinline: '',           // iOS: avoid fullscreen jumps
+      preload: 'metadata',
+      playsinline: '',
     };
     if (poster) videoAttrs.poster = poster; // Also set poster on <video>
     const video = createTag('video', videoAttrs);
@@ -277,10 +274,8 @@ class MobileRider {
 
     if (!window.mobilerider) return;
 
-    // Remove poster when we have data (or after a short fallback)
     const cleanup = () => removePoster();
     video.addEventListener('loadeddata', cleanup, { once: true });
-    // Fallback: in case the player fires custom events or takes longer
     setTimeout(cleanup, 4000);
 
     window.mobilerider.embed(video.id, vid, skin, {
@@ -293,7 +288,6 @@ class MobileRider {
     });
 
     if (asl) this.initASL();
-    // Check store existence first, then check mainID or vid in store
     if (this.store) {
       let key = null;
       if (this.mainID && this.store.get(this.mainID) !== undefined) {
@@ -310,7 +304,6 @@ class MobileRider {
   onStreamEnd(vid) {
     window.__mr_player?.off('streamend');
     window.__mr_player?.on('streamend', () => {
-      // Remove drawer if it exists
       if (this.drawer) {
         this.drawer.remove();
         this.drawer = null;
@@ -373,7 +366,7 @@ class MobileRider {
 
         const vidCon = createTag('div', { class: 'drawer-item-content' });
         if (v.title) vidCon.appendChild(createTag('div', { class: 'drawer-item-title' }, v.title));
-        // if (v.description) vidCon.appendChild(createTag('div', { class: 'drawer-item-description' }, v.description));
+        if (v.description) vidCon.appendChild(createTag('div', { class: 'drawer-item-description' }, v.description));
         item.appendChild(vidCon);
 
         return item;

--- a/events/blocks/mobile-rider/mobile-rider.js
+++ b/events/blocks/mobile-rider/mobile-rider.js
@@ -373,7 +373,7 @@ class MobileRider {
 
         const vidCon = createTag('div', { class: 'drawer-item-content' });
         if (v.title) vidCon.appendChild(createTag('div', { class: 'drawer-item-title' }, v.title));
-        if (v.description) vidCon.appendChild(createTag('div', { class: 'drawer-item-description' }, v.description));
+        // if (v.description) vidCon.appendChild(createTag('div', { class: 'drawer-item-description' }, v.description));
         item.appendChild(vidCon);
 
         return item;

--- a/events/blocks/mobile-rider/mobile-rider.js
+++ b/events/blocks/mobile-rider/mobile-rider.js
@@ -25,7 +25,87 @@ const CONFIG = {
     PROD_URL: 'https://overlay-admin-integration.mobilerider.com',
     DEV_URL: 'https://overlay-admin-integration.mobilerider.com',
   },
+  STORAGE: {
+    CURRENT_VIDEO_KEY: 'mobile-rider-current-video',
+  },
 };
+
+// --- Storage helpers ---------------------------------------------------------
+
+/**
+ * Save the current video state to sessionStorage
+ * @param {string} videoId - The video ID that is currently playing
+ * @param {string} mainId - The main session ID for concurrent streams
+ */
+function saveCurrentVideo(videoId, mainId = null) {
+  try {
+    const data = {
+      videoId,
+      mainId,
+    };
+    sessionStorage.setItem(CONFIG.STORAGE.CURRENT_VIDEO_KEY, JSON.stringify(data));
+  } catch (e) {
+    window.lana?.log(`Failed to save current video state: ${e.message}`);
+  }
+}
+
+/**
+ * Get the saved current video state from sessionStorage
+ * @returns {Object|null} The saved video state or null if not found
+ */
+function getCurrentVideo() {
+  try {
+    const data = sessionStorage.getItem(CONFIG.STORAGE.CURRENT_VIDEO_KEY);
+
+    if (!data) return null;
+
+    return JSON.parse(data);
+  } catch (e) {
+    window.lana?.log(`Failed to get current video state: ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Clear the saved current video state
+ */
+function clearCurrentVideo() {
+  try {
+    sessionStorage.removeItem(CONFIG.STORAGE.CURRENT_VIDEO_KEY);
+  } catch (e) {
+    window.lana?.log(`Failed to clear current video state: ${e.message}`);
+  }
+}
+
+// --- LCP helpers -------------------------------------------------------------
+function preloadPoster(url) {
+  if (!url) return;
+  const sel = `link[rel="preload"][as="image"][href="${url}"]`;
+  if (!document.querySelector(sel)) {
+    const l = document.createElement('link');
+    l.rel = 'preload';
+    l.as = 'image';
+    l.href = url;
+    document.head.appendChild(l);
+  }
+}
+
+function showPosterPlaceholder(container, poster, altText = 'Video poster') {
+  if (!poster || !container) return () => {};
+  let img = container.querySelector('.mr-poster');
+  if (!img) {
+    img = createTag('img', {
+      src: poster,
+      alt: altText,
+      class: 'mr-poster',
+      fetchpriority: 'high',
+      loading: 'eager',
+      decoding: 'async',
+    });
+    container.appendChild(img);
+  }
+  return () => img?.remove();
+}
 
 let scriptPromise = null;
 
@@ -53,7 +133,16 @@ class MobileRider {
     this.root = null;
     this.store = null;
     this.mainID = null;
+    this.currentVideoId = null;
+    this.drawer = null;
     this.init();
+
+    // Save current video state before page unload
+    window.addEventListener('beforeunload', () => {
+      if (this.currentVideoId && this.cfg?.concurrentenabled) {
+        saveCurrentVideo(this.currentVideoId, this.mainID);
+      }
+    });
   }
 
   async init() {
@@ -79,7 +168,19 @@ class MobileRider {
       const isConcurrent = this.cfg.concurrentenabled;
       const videos = isConcurrent ? this.cfg.concurrentVideos : [this.cfg];
 
-      const { videoid, aslid } = videos[0];
+      const savedVideo = getCurrentVideo();
+      let initialVideo = videos[0];
+
+      if (savedVideo && isConcurrent) {
+        // Find the saved video in the concurrent videos array
+        const savedVideoObj = videos.find(v => v.videoid === savedVideo.videoId);
+        if (savedVideoObj) {
+          initialVideo = savedVideoObj;
+          window.lana?.log(`Restoring saved video: ${savedVideo.videoId}`);
+        }
+      }
+
+      const { videoid, aslid } = initialVideo;
       if (!videoid) {
         window.lana?.log('Missing video-id in config.');
         return;
@@ -87,11 +188,22 @@ class MobileRider {
 
       // Set mainID for concurrent streams
       if (isConcurrent && this.store) {
-        this.mainID = videos[0].videoid;
+        this.mainID = savedVideo?.mainId || videos[0].videoid;
       }
 
       await this.loadPlayer(videoid, aslid);
-      if (isConcurrent && videos.length > 1) await this.initDrawer(videos);
+      // Save the initial video state for concurrent streams
+      if (isConcurrent) {
+        saveCurrentVideo(videoid, this.mainID);
+      }
+
+      if (isConcurrent && videos.length > 1) {
+        await this.initDrawer(videos);
+        // Update drawer active state to match the restored video
+        if (savedVideo && this.drawer) {
+          this.drawer.setActiveById(videoid);
+        }
+      }
     } catch (e) {
       window.lana?.log(`MobileRider Init error: ${e.message}`);
     }
@@ -125,7 +237,7 @@ class MobileRider {
 
   injectPlayer(vid, skin, asl = null) {
     if (!this.wrap) return;
-
+    this.currentVideoId = vid;
     let con = this.wrap.querySelector('.mobile-rider-container');
     if (!con) {
       con = createTag('div', {
@@ -140,23 +252,44 @@ class MobileRider {
       Object.assign(con.dataset, { videoid: vid, skinid: skin, aslid: asl });
     }
 
+    // --- LCP: add poster preload + placeholder before we touch <video> -------
+    const poster = this.cfg.poster || this.cfg.thumbnail;
+    if (poster) {
+      preloadPoster(poster);
+    }
+    const removePoster = showPosterPlaceholder(con, poster, this.cfg.title || 'Video poster');
+
+    // -------------------------------------------------------------------------
+
     window.__mr_player?.dispose();
     con.querySelector(`#${CONFIG.PLAYER.VIDEO_ID}`)?.remove();
 
-    const video = createTag('video', {
+    const videoAttrs = {
       id: CONFIG.PLAYER.VIDEO_ID,
       class: CONFIG.PLAYER.VIDEO_CLASS,
       controls: true,
-    });
+      preload: 'metadata',       // LCP-friendly
+      playsinline: '',           // iOS: avoid fullscreen jumps
+    };
+    if (poster) videoAttrs.poster = poster; // Also set poster on <video>
+    const video = createTag('video', videoAttrs);
     con.appendChild(video);
 
     if (!window.mobilerider) return;
+
+    // Remove poster when we have data (or after a short fallback)
+    const cleanup = () => removePoster();
+    video.addEventListener('loadeddata', cleanup, { once: true });
+    // Fallback: in case the player fires custom events or takes longer
+    setTimeout(cleanup, 4000);
+
     window.mobilerider.embed(video.id, vid, skin, {
       ...this.getPlayerOptions(),
       analytics: { provider: CONFIG.ANALYTICS.PROVIDER },
       identifier1: vid,
       identifier2: asl,
       sessionId: vid,
+      poster,
     });
 
     if (asl) this.initASL();
@@ -177,8 +310,14 @@ class MobileRider {
   onStreamEnd(vid) {
     window.__mr_player?.off('streamend');
     window.__mr_player?.on('streamend', () => {
+      // Remove drawer if it exists
+      if (this.drawer) {
+        this.drawer.remove();
+        this.drawer = null;
+      }
       this.setStatus(vid, false);
       MobileRider.dispose();
+      clearCurrentVideo();
     });
   }
 
@@ -186,6 +325,7 @@ class MobileRider {
     window.__mr_player?.dispose();
     window.__mr_player = null;
     window.__mr_stream_published = null;
+    clearCurrentVideo();
   }
 
   static loadDrawerCSS() {
@@ -239,14 +379,14 @@ class MobileRider {
         return item;
       };
 
-      const drawer = createDrawer(this.root, {
+      this.drawer = createDrawer(this.root, {
         items: videos,
         ariaLabel: 'Videos',
         renderItem,
         onItemClick: (_, v) => this.onDrawerClick(v),
       });
 
-      const itemsList = drawer?.itemsEl;
+      const itemsList = this.drawer?.itemsEl;
       if (itemsList?.firstChild) {
         itemsList.insertBefore(this.drawerHeading(), itemsList.firstChild);
       }
@@ -261,7 +401,16 @@ class MobileRider {
         const live = await this.checkLive(v);
         if (!live) window.lana?.log(`This stream is not currently live: ${v.videoid}`);
       }
+      // Save the current video state when user switches videos
+      if (this.cfg.concurrentenabled) {
+        saveCurrentVideo(v.videoid, this.mainID);
+        this.currentVideoId = v.videoid;
+      }
       this.injectPlayer(v.videoid, this.cfg.skinid, v.aslid);
+      // Update drawer active state
+      if (this.drawer) {
+        this.drawer.setActiveById(v.videoid);
+      }
     } catch (e) {
       window.lana?.log(`Drawer item click error: ${e.message}`);
     }

--- a/events/features/timing-framework/worker.js
+++ b/events/features/timing-framework/worker.js
@@ -251,6 +251,21 @@ class TimingWorker {
   }
 
   /**
+   * Check if toggleTime has passed for a schedule item
+   * @param {Object} scheduleItem
+   * @returns {Promise<boolean>}
+   */
+  async hasToggleTimePassed(scheduleItem) {
+    const { toggleTime } = scheduleItem;
+    if (!toggleTime) return true; // No toggleTime means no time restriction
+    
+    const currentTime = await this.getCurrentTime();
+    // Convert toggleTime to number if it's a string
+    const numericToggleTime = typeof toggleTime === 'string' ? parseInt(toggleTime, 10) : toggleTime;
+    return currentTime > numericToggleTime;
+  }
+
+  /**
    * @param {Object} scheduleItem
    * @returns {boolean}
    * @description Returns true if the next schedule item should be triggered based on plugins
@@ -265,21 +280,16 @@ class TimingWorker {
         const { sessionId } = this.currentScheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
         if (isActive) return false; // Wait for session to end
+         // Check if current item has mobileRider that's ended (underrun)
         return true;
       }
     }
 
-    // Check if current item has mobileRider that's ended (underrun)
     if (scheduleItem.mobileRider) {
-      const { toggleTime } = scheduleItem;
-      let timePassed = false;
-      if (toggleTime) {
-        const currentTime = await this.getCurrentTime();
-        // Convert toggleTime to number if it's a string
-        const numericToggleTime = typeof toggleTime === 'string' ? parseInt(toggleTime, 10) : toggleTime;
-        timePassed = currentTime > numericToggleTime;
-      }
+      // Check if toggleTime has passed before checking mobileRider status
+      const timePassed = await this.hasToggleTimePassed(scheduleItem);
       if (!timePassed) return false;
+      
       const mobileRiderStore = this.plugins.get('mobileRider');
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
@@ -311,16 +321,7 @@ class TimingWorker {
     }
 
     // If no plugins are blocking, check toggleTime
-    const { toggleTime } = scheduleItem;
-    if (toggleTime) {
-      const currentTime = await this.getCurrentTime();
-      // Convert toggleTime to number if it's a string
-      const numericToggleTime = typeof toggleTime === 'string' ? parseInt(toggleTime, 10) : toggleTime;
-      const timePassed = currentTime > numericToggleTime;
-      return timePassed;
-    }
-
-    return true;
+    return await this.hasToggleTimePassed(scheduleItem);
   }
 
   async runTimer() {

--- a/events/features/timing-framework/worker.js
+++ b/events/features/timing-framework/worker.js
@@ -265,16 +265,29 @@ class TimingWorker {
         const { sessionId } = this.currentScheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
         if (isActive) return false; // Wait for session to end
+        return true;
       }
     }
 
     // Check if current item has mobileRider that's ended (underrun)
     if (scheduleItem.mobileRider) {
+      const { toggleTime } = scheduleItem;
+      let timePassed = false;
+      if (toggleTime) {
+        const currentTime = await this.getCurrentTime();
+        // Convert toggleTime to number if it's a string
+        const numericToggleTime = typeof toggleTime === 'string' ? parseInt(toggleTime, 10) : toggleTime;
+        timePassed = currentTime > numericToggleTime;
+      }
+      if (!timePassed) return false;
       const mobileRiderStore = this.plugins.get('mobileRider');
       if (mobileRiderStore) {
         const { sessionId } = scheduleItem.mobileRider;
         const isActive = mobileRiderStore.get(sessionId);
-        if (!isActive) return true;
+        if (!isActive) {
+          this.nextScheduleItem = scheduleItem.next;
+          return true;
+        }
       }
     }
 

--- a/test/unit/blocks/mobile-rider/drawer.test.js
+++ b/test/unit/blocks/mobile-rider/drawer.test.js
@@ -377,7 +377,13 @@ describe('Mobile Rider Drawer', () => {
       itemsEl = document.createElement('div');
       const el1 = document.createElement('div');
       el1.setAttribute('data-id', 'vid1');
+      el1.classList.add('drawer-item'); // Add the required class
       itemsEl.appendChild(el1);
+
+      const el2 = document.createElement('div');
+      el2.setAttribute('data-id', 'vid2');
+      el2.classList.add('drawer-item'); // Add the required class
+      itemsEl.appendChild(el2);
 
       const root = document.createElement('div');
       drawer = createDrawer(root, { items });
@@ -390,11 +396,12 @@ describe('Mobile Rider Drawer', () => {
       sinon.restore();
     });
 
-    it('should call setActive with correct element and item in setActiveById', () => {
+    it('should update visual state without calling setActive in setActiveById', () => {
       drawer.setActiveById('vid1');
-      expect(drawer.setActive.calledOnce).to.be.true;
-      expect(drawer.setActive.firstCall.args[0].getAttribute('data-id')).to.equal('vid1');
-      expect(drawer.setActive.firstCall.args[1]).to.deep.equal(items[0]);
+      expect(drawer.setActive.called).to.be.false;
+      // Verify the visual state is updated directly
+      const currentElement = drawer.itemsEl.querySelector('.drawer-item.current');
+      expect(currentElement.getAttribute('data-id')).to.equal('vid1');
     });
 
     it('should do nothing if id not found in setActiveById', () => {


### PR DESCRIPTION
1. Poster image has been added to get the better LCP for MR rider player added.
2. Feature gap: for concurrent users, video2 reverts to video1 on reload/refresh instead of remaining on video2 **fixed**.
3. fixes of text color, description existence, missing play button on thumbnails, and background color on mouseover tiles **fixed**.
4. live badge is slightly out of alignment **fixed**.
5. Given the current block’s live stream is inactive, when the scheduled time is reached, then the block should skip the current block, and load the next fragment. (Live stream ends early) **Fixed**

Resolves: https://jira.corp.adobe.com/browse/MWPW-178581, https://jira.corp.adobe.com/browse/MWPW-173499

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.page/events/fragments/event-templates/timing-framework-poc/dme/simple
- After: https://mobile-rider-fixes--events-milo--adobecom.aem.page/events/fragments/event-templates/timing-framework-poc/dme/simple

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
