### PR TITLE
Prevent invalid promotional item mapping

### DIFF
--- a/events/blocks/promotional-content/promotional-content.js
+++ b/events/blocks/promotional-content/promotional-content.js
@@ -5,7 +5,8 @@ async function getPromotionalContent() {
   const eventPromotionalItemsMetadata = getMetadata('promotional-items');
   if (eventPromotionalItemsMetadata) {
     try {
-      promotionalItems = JSON.parse(eventPromotionalItemsMetadata);
+      const promotionalItemsMetadata = JSON.parse(eventPromotionalItemsMetadata);
+      promotionalItems = promotionalItemsMetadata.filter((item) => item.name);
     } catch (error) {
       window.lana?.log(`Error parsing promotional items: ${JSON.stringify(error)}`);
       return promotionalItems;


### PR DESCRIPTION
Fixes a runtime error with malformed empty promotional content JSON data.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

<img width="780" height="95" alt="Screenshot 2025-08-27 at 3 48 01 PM" src="https://github.com/user-attachments/assets/5c5839f3-22cb-406f-b7a7-d9c03f05a976" />
<img width="1071" height="98" alt="Screenshot 2025-08-27 at 3 47 58 PM" src="https://github.com/user-attachments/assets/a1cfde9c-7c7a-4a3e-a008-7965f82f5095" />

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://promotiona-content-fix--events-milo--adobecom.aem.live/drafts/