### PR TITLE
Reintroduce and expanded the pre/during/post logic as global DOM flag

### DIFF
--- a/events/blocks/event-agenda/event-agenda.js
+++ b/events/blocks/event-agenda/event-agenda.js
@@ -18,7 +18,7 @@ export function convertToLocaleTimeFormat(time, locale) {
 }
 
 export default async function init(el) {
-  if (getMetadata('show-agenda-post-event') !== 'true' && document.body.classList.contains('timing-post-event')) {
+  if (getMetadata('show-agenda-post-event') !== 'true' && document.body.dataset.eventState === 'post-event') {
     el.remove();
     return;
   }

--- a/events/blocks/event-map/event-map.js
+++ b/events/blocks/event-map/event-map.js
@@ -50,7 +50,7 @@ function decorateTextContainer(el, createTag, decorateButtons) {
     if (city && state && postalCode) createTag('p', { class: 'venue-address-text' }, `${city}, ${state} ${postalCode}`, { parent: textContentWrapper });
   }
 
-  if (getMetadata('show-venue-additional-info-post-event') !== 'true' && document.body.classList.contains('timing-post-event')) return;
+  if (getMetadata('show-venue-additional-info-post-event') !== 'true' && document.body.dataset.eventState === 'post-event') return;
 
   if (additionalInfoBtn && (additionalInformation || venueAdditionalImageObj)) {
     decorateButtons(additionalInfoBtn, 'button-l');
@@ -101,7 +101,7 @@ export default async function init(el) {
     import(`${LIBS}/utils/utils.js`),
     import(`${LIBS}/utils/decorate.js`),
   ]);
-  if (getMetadata('show-venue-post-event') !== 'true' && document.body.classList.contains('timing-post-event')) {
+  if (getMetadata('show-venue-post-event') !== 'true' && document.body.dataset.eventState === 'post-event') {
     el.remove();
     return;
   }

--- a/events/blocks/venue-additional-info/venue-additional-info.js
+++ b/events/blocks/venue-additional-info/venue-additional-info.js
@@ -71,7 +71,7 @@ function decorateModal(el, createTag) {
 export default async function init(el) {
   const { createTag } = await import(`${LIBS}/utils/utils.js`);
 
-  if (getMetadata('show-venue-additional-info-post-event') !== 'true' && document.body.classList.contains('timing-post-event')) {
+  if (getMetadata('show-venue-additional-info-post-event') !== 'true' && document.body.dataset.eventState === 'post-event') {
     el.remove();
     return;
   }

--- a/events/scripts/content-update.js
+++ b/events/scripts/content-update.js
@@ -606,6 +606,28 @@ function updateExtraMetaTags(parent) {
   }
 }
 
+function flagEventState(parent) {
+  if (parent !== document) return;
+
+  const localStartMillis = getMetadata('local-start-time-millis');
+  const localEndMillis = getMetadata('local-end-time-millis');
+
+  if (!localStartMillis || !localEndMillis) return;
+
+  const now = Date.now();
+  const isBeforeStart = now < localStartMillis;
+  const isAfterEnd = now > localEndMillis;
+  const isDuringEvent = now >= localStartMillis && now <= localEndMillis;
+
+  if (isBeforeStart) {
+    document.body.dataset.eventState = 'pre-event';
+  } else if (isAfterEnd) {
+    document.body.dataset.eventState = 'post-event';
+  } else if (isDuringEvent) {
+    document.body.dataset.eventState = 'during-event';
+  }
+}
+
 // data -> dom gills
 export default function autoUpdateContent(parent, miloDeps, extraData) {
   const { getConfig, miloLibs } = miloDeps;
@@ -668,6 +690,8 @@ export default function autoUpdateContent(parent, miloDeps, extraData) {
       });
     }
   });
+
+  flagEventState(parent);
 
   // handle link replacement. To keep when switching to metadata based rendering
   autoUpdateLinks(parent, miloLibs);

--- a/test/unit/blocks/event-agenda/event-agenda.test.js
+++ b/test/unit/blocks/event-agenda/event-agenda.test.js
@@ -183,8 +183,8 @@ describe('Agenda Module', () => {
       expect(el.parentNode).to.be.null;
     });
 
-    it('should remove element if metadata "show-agenda-post-event" is not "true" and body has class "timing-post-event"', async () => {
-      document.body.classList.add('timing-post-event');
+    it('should remove element if metadata "show-agenda-post-event" is not "true" and body has eventState "post-event"', async () => {
+      document.body.dataset.eventState = 'post-event';
       setMetadata('show-agenda-post-event', 'false');
 
       const el = document.querySelector('.event-agenda');

--- a/test/unit/blocks/event-map/event-map.test.js
+++ b/test/unit/blocks/event-map/event-map.test.js
@@ -9,7 +9,7 @@ const faulty = await readFile({ path: './mocks/faulty.html' });
 describe('Event Map', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
-    document.body.classList.remove('timing-post-event');
+    delete document.body.dataset.eventState;
     document.head.innerHTML = '';
     window.isTestEnv = true;
     setMetadata('venue', JSON.stringify({
@@ -48,7 +48,7 @@ describe('Event Map', () => {
   it('event map does not exist when toggled off for post event', async () => {
     setMetadata('show-venue-post-event', 'false');
     document.body.innerHTML = body;
-    document.body.classList.add('timing-post-event');
+    document.body.dataset.eventState = 'post-event';
     const block = document.querySelector('.event-map');
     await init(block);
     expect(document.querySelector('.event-map')).to.not.exist;
@@ -58,7 +58,7 @@ describe('Event Map', () => {
     setMetadata('show-venue-post-event', 'true');
     setMetadata('show-venue-additional-info-post-event', 'false');
     document.body.innerHTML = body;
-    document.body.classList.add('timing-post-event');
+    document.body.dataset.eventState = 'post-event';
     const block = document.querySelector('.event-map');
     await init(block);
     expect(document.querySelector('.event-map .event-map-wrapper > div > p:last-of-type:has(a)')).to.not.exist;
@@ -68,7 +68,7 @@ describe('Event Map', () => {
     setMetadata('show-venue-post-event', 'true');
     setMetadata('show-venue-additional-info-post-event', 'true');
     document.body.innerHTML = body;
-    document.body.classList.add('timing-post-event');
+    document.body.dataset.eventState = 'post-event';
     const block = document.querySelector('.event-map');
     await init(block);
     expect(document.querySelector('.event-map .event-map-wrapper > div > p:last-of-type:has(a)')).to.exist;

--- a/test/unit/blocks/venue-additional-info/venue-additional-info.test.js
+++ b/test/unit/blocks/venue-additional-info/venue-additional-info.test.js
@@ -8,7 +8,7 @@ const body = await readFile({ path: './mocks/default.html' });
 describe('Venue Additional Info', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
-    document.body.classList.remove('timing-post-event');
+    delete document.body.dataset.eventState;
     document.head.innerHTML = '';
     window.isTestEnv = true;
   });


### PR DESCRIPTION
Added back the pre/during/post event context in DOM globally without integrating with TF. These time comparison will be done without Akamai validation.

Resolves: https://jira.corp.adobe.com/browse/MWPW-179432

Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
