### PR TITLE
Fix promotionalItem format mismatch with backward compatibility

### DIFF
--- a/events/blocks/promotional-content/promotional-content.js
+++ b/events/blocks/promotional-content/promotional-content.js
@@ -6,7 +6,12 @@ async function getPromotionalContent() {
   if (eventPromotionalItemsMetadata) {
     try {
       const promotionalItemsMetadata = JSON.parse(eventPromotionalItemsMetadata);
-      promotionalItems = promotionalItemsMetadata.filter((item) => item.name);
+      promotionalItems = promotionalItemsMetadata.filter((item) => {
+        if (typeof item === 'object') {
+          return item.name;
+        }
+        return item;
+      });
     } catch (error) {
       window.lana?.log(`Error parsing promotional items: ${JSON.stringify(error)}`);
       return promotionalItems;


### PR DESCRIPTION
Resolves: [MWPW-180257](https://jira.corp.adobe.com/browse/MWPW-180257)

Test URLs:
- Before: https://<BASE_BRANCH>--events-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
