### PR TITLE
Fixing error message based ESP 400 error handling

### DIFF
--- a/events/blocks/events-form/events-form.js
+++ b/events/blocks/events-form/events-form.js
@@ -270,9 +270,11 @@ function createButton({ type, label }, bp) {
         button.setAttribute('disabled', true);
         button.classList.add('submitting');
         const respJson = await submitForm(bp);
-        button.removeAttribute('disabled');
-        button.classList.remove('submitting');
-        if (!respJson) return;
+        if (!respJson) {
+          button.removeAttribute('disabled');
+          button.classList.remove('submitting');
+          return;
+        }
 
         if (respJson.ok) {
           BlockMediator.set('rsvpData', respJson.data);
@@ -280,8 +282,7 @@ function createButton({ type, label }, bp) {
         } else {
           const { status } = respJson;
 
-          if (status === 400 && respJson.error?.message === 'Request to ESP failed: Event is full') {
-            BlockMediator.set('rsvpData', null);
+          if (status === 400) {
             const eventResp = await getEvent(getMetadata('event-id'));
             if (eventResp.ok) {
               const { isFull, allowWaitlisting, attendeeCount, attendeeLimit } = eventResp.data;
@@ -298,10 +299,15 @@ function createButton({ type, label }, bp) {
                 }
               }
             }
+
+            BlockMediator.set('rsvpData', null);
           }
 
           buildErrorMsg(bp.form, status);
         }
+
+        button.removeAttribute('disabled');
+        button.classList.remove('submitting');
       }
     });
   }


### PR DESCRIPTION
As the error message changes, our 400 error handling for the user hitting the event full threshold is no longer working properly. 

The FE shouldn't have used error message to determine the kind of 400 error. This PR should fix this issue.

Resolves: [MWPW-180672](https://jira.corp.adobe.com/browse/MWPW-180672)

Test URLs:
- Before: https://dev--events-milo--adobecom.aem.live/drafts/
- After: https://mwpw-180672--events-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
